### PR TITLE
[macho_parser] Use mmap instead of loading file

### DIFF
--- a/macho_parser/sources/argument.c
+++ b/macho_parser/sources/argument.c
@@ -84,3 +84,7 @@ bool show_command(unsigned int cmd) {
     }
     return show;
 }
+
+bool show_header() {
+    return args.command_count == 0;
+}

--- a/macho_parser/sources/argument.h
+++ b/macho_parser/sources/argument.h
@@ -30,4 +30,7 @@ unsigned int string_to_load_command(char *cmd_str);
 // whether to show a command
 bool show_command(unsigned int cmd);
 
+// whether to show header
+bool show_header();
+
 #endif /* ARGUMENT_H */

--- a/macho_parser/sources/build_version.c
+++ b/macho_parser/sources/build_version.c
@@ -7,7 +7,7 @@ static void get_tool_name(uint32_t tool, char *tool_name);
 static void get_platform_name(uint32_t platform, char *platform_name);
 static void get_version_string(uint32_t version, char *version_string);
 
-void parse_build_version(FILE *fptr, struct build_version_command *build_version_cmd) {
+void parse_build_version(void *base, struct build_version_command *build_version_cmd) {
     char platform_name[128];
     char minos_string[128];
     char sdk_string[128];
@@ -39,7 +39,7 @@ void parse_build_version(FILE *fptr, struct build_version_command *build_version
     }
 }
 
-void parse_version_min(FILE *fptr, struct version_min_command *version_min_cmd) {
+void parse_version_min(void *base, struct version_min_command *version_min_cmd) {
     char *cmd_name = NULL;
     switch (version_min_cmd->cmd) {
         case LC_VERSION_MIN_MACOSX: cmd_name = "LC_VERSION_MIN_MACOSX"; break;

--- a/macho_parser/sources/build_version.h
+++ b/macho_parser/sources/build_version.h
@@ -5,9 +5,9 @@
 #include <mach-o/loader.h>
 
 // parse LC_BUILD_VERSION
-void parse_build_version(FILE *fptr, struct build_version_command *build_version_cmd);
+void parse_build_version(void *base, struct build_version_command *build_version_cmd);
 
 // parse LC_VERSION_MIN_MACOSX, LC_VERSION_MIN_IPHONEOS, LC_VERSION_MIN_WATCHOS, LC_VERSION_MIN_TVOS
-void parse_version_min(FILE *fptr, struct version_min_command *version_min_cmd);
+void parse_version_min(void *base, struct version_min_command *version_min_cmd);
 
 #endif /* BUILD_VERSION_H */

--- a/macho_parser/sources/chained_fixups.c
+++ b/macho_parser/sources/chained_fixups.c
@@ -54,7 +54,7 @@ void parse_chained_fixups(void *base, uint32_t dataoff, uint32_t datasize) {
 
             if (page_starts[j] == DYLD_CHAINED_PTR_START_NONE) { continue; }
 
-            uint16_t chain = starts_in_segment->segment_offset + starts_in_segment->page_size * j + page_starts[j];
+            uint32_t chain = starts_in_segment->segment_offset + starts_in_segment->page_size * j + page_starts[j];
 
             bool done = false;
             while (!done) {

--- a/macho_parser/sources/chained_fixups.c
+++ b/macho_parser/sources/chained_fixups.c
@@ -15,14 +15,13 @@ static void print_imports(struct dyld_chained_fixups_header *header);
 static void format_pointer_format(uint16_t pointer_format, char *formatted);
 
 void parse_chained_fixups(void *base, uint32_t dataoff, uint32_t datasize) {
-    // void *base_addr = mmap(NULL, datasize, PROT_READ, MAP_PRIVATE, fileno(fptr), dataoff);
-    void *base_addr = base + dataoff;
+    void *fixup_base = base + dataoff;
 
-    struct dyld_chained_fixups_header *header = base_addr;
+    struct dyld_chained_fixups_header *header = fixup_base;
     print_chained_fixups_header(header);
     print_imports(header);
 
-    struct dyld_chained_starts_in_image *starts_in_image = base_addr + header->starts_offset;
+    struct dyld_chained_starts_in_image *starts_in_image = fixup_base + header->starts_offset;
     // printf("    STARTS IN IMAGE\n");
     // printf("    seg_count: %d\n", starts_in_image->seg_count);
     // printf("    seg_info_offset: %d\n", starts_in_image->seg_info_offset[0]);
@@ -37,7 +36,7 @@ void parse_chained_fixups(void *base, uint32_t dataoff, uint32_t datasize) {
             continue;
         }
 
-        struct dyld_chained_starts_in_segment* starts_in_segment = base + dataoff + header->starts_offset + offsets[i]; // load_bytes(fptr, dataoff + header->starts_offset + offsets[i], sizeof(struct dyld_chained_starts_in_segment));
+        struct dyld_chained_starts_in_segment* starts_in_segment = base + dataoff + header->starts_offset + offsets[i];
         char formatted_pointer_format[256];
         format_pointer_format(starts_in_segment->pointer_format, formatted_pointer_format);
 
@@ -63,8 +62,8 @@ void parse_chained_fixups(void *base, uint32_t dataoff, uint32_t datasize) {
                     || starts_in_segment->pointer_format == DYLD_CHAINED_PTR_64_OFFSET) {
                     struct dyld_chained_ptr_64_bind bind = *(struct dyld_chained_ptr_64_bind *)(base + chain);
                     if (bind.bind) {
-                        struct dyld_chained_import import = ((struct dyld_chained_import *)(base_addr + header->imports_offset))[bind.ordinal];
-                        char *symbol = (char *)(base_addr+ header->symbols_offset + import.name_offset);
+                        struct dyld_chained_import import = ((struct dyld_chained_import *)(fixup_base + header->imports_offset))[bind.ordinal];
+                        char *symbol = fixup_base + header->symbols_offset + import.name_offset;
                         printf("        0x%08x BIND     ordinal: %d   addend: %d    reserved: %d   (%s)\n",
                             chain, bind.ordinal, bind.addend, bind.reserved, symbol);
                     } else {
@@ -88,8 +87,6 @@ void parse_chained_fixups(void *base, uint32_t dataoff, uint32_t datasize) {
             printf("\n");
         }
     }
-
-    munmap(base_addr, datasize);
 }
 
 static void print_chained_fixups_header(struct dyld_chained_fixups_header *header) {

--- a/macho_parser/sources/chained_fixups.h
+++ b/macho_parser/sources/chained_fixups.h
@@ -4,6 +4,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-void parse_chained_fixups(FILE *fptr, uint32_t dataoff, uint32_t datasize);
+void parse_chained_fixups(void *base, uint32_t dataoff, uint32_t datasize);
 
 #endif /* CHAINED_FIXUPS_H */

--- a/macho_parser/sources/dyld_info.c
+++ b/macho_parser/sources/dyld_info.c
@@ -23,8 +23,7 @@ void parse_dyld_info(void *base, struct dyld_info_command *dyld_info_cmd) {
 }
 
 void parse_export(void *base, uint32_t export_off, uint32_t export_size) {
-    uint8_t *export = base + export_off; //load_bytes(fptr, export_off, export_size);
-
+    uint8_t *export = base + export_off;
     printf ("\n    Exported Symbols (Trie):");
     parse_export_trie(export, export, 0);
 }

--- a/macho_parser/sources/dyld_info.c
+++ b/macho_parser/sources/dyld_info.c
@@ -4,10 +4,10 @@
 #include "dyld_info.h"
 #include "util.h"
 
-void parse_export(FILE *fptr, uint32_t export_off, uint32_t export_size);
+void parse_export(void *base, uint32_t export_off, uint32_t export_size);
 void parse_export_trie(uint8_t *export_start, uint8_t *node_ptr, int level);
 
-void parse_dyld_info(FILE *fptr, struct dyld_info_command *dyld_info_cmd) {
+void parse_dyld_info(void *base, struct dyld_info_command *dyld_info_cmd) {
     const char *name = (dyld_info_cmd->cmd == LC_DYLD_INFO_ONLY ? "LC_DYLD_INFO_ONLY" : "LC_DYLD_INFO");
     printf("%-20s cmdsize: %-6u export_size: %d\n", name, dyld_info_cmd->cmdsize, dyld_info_cmd->export_size);
 
@@ -19,16 +19,14 @@ void parse_dyld_info(FILE *fptr, struct dyld_info_command *dyld_info_cmd) {
     printf("    lazy_bind_off: %-10d   lazy_bind_size: %d\n", dyld_info_cmd->lazy_bind_off, dyld_info_cmd->lazy_bind_size);
     printf("    export_off   : %-10d   export_size   : %d\n", dyld_info_cmd->export_off, dyld_info_cmd->export_size);
 
-    parse_export(fptr, dyld_info_cmd->export_off, dyld_info_cmd->export_size);
+    parse_export(base, dyld_info_cmd->export_off, dyld_info_cmd->export_size);
 }
 
-void parse_export(FILE *fptr, uint32_t export_off, uint32_t export_size) {
-    uint8_t *export = load_bytes(fptr, export_off, export_size);
+void parse_export(void *base, uint32_t export_off, uint32_t export_size) {
+    uint8_t *export = base + export_off; //load_bytes(fptr, export_off, export_size);
 
     printf ("\n    Exported Symbols (Trie):");
     parse_export_trie(export, export, 0);
-
-    free(export);
 }
 
 // Print out the export trie.

--- a/macho_parser/sources/dyld_info.h
+++ b/macho_parser/sources/dyld_info.h
@@ -4,6 +4,6 @@
 #include <stdio.h>
 #include <mach-o/loader.h>
 
-void parse_dyld_info(FILE *fptr, struct dyld_info_command *dyld_info_cmd);
+void parse_dyld_info(void *base, struct dyld_info_command *dyld_info_cmd);
 
 #endif /* DYLD_INFO_H */

--- a/macho_parser/sources/dysymtab.c
+++ b/macho_parser/sources/dysymtab.c
@@ -57,9 +57,9 @@ void load_symtab_cmd(void *base, void **sym_table, void **str_table) {
         struct load_command *lcmd = base + offset;
 
         if (lcmd->cmd == LC_SYMTAB) {
-            struct symtab_command *symtab_cmd = base + offset; // load_bytes(fptr, offset, lcmd->cmdsize);
-            *sym_table = base + symtab_cmd->symoff; //load_bytes(base, symtab_cmd->symoff, symtab_cmd->nsyms * sizeof(struct nlist_64));
-            *str_table = base + symtab_cmd->stroff; //load_bytes(base, symtab_cmd->stroff, symtab_cmd->strsize);
+            struct symtab_command *symtab_cmd = base + offset;
+            *sym_table = base + symtab_cmd->symoff;
+            *str_table = base + symtab_cmd->stroff;
             return;
         }
 

--- a/macho_parser/sources/dysymtab.c
+++ b/macho_parser/sources/dysymtab.c
@@ -5,13 +5,11 @@
 
 #define MIN(a,b) ((a) < (b) ? (a) : (b))
 
-extern void *load_bytes(FILE *fptr, int offset, int size);
-
-void load_symtab_cmd(FILE *fptr, void **sym_table, void **str_table);
+void load_symtab_cmd(void *base, void **sym_table, void **str_table);
 void print_symbols(void *sym_table, void *str_table, int offset, int num);
 void print_indirect_symbols(void *sym_table, void *str_table, uint32_t *indirect_symtab, int size);
 
-void parse_dynamic_symbol_table(FILE *fptr, struct dysymtab_command *dysymtab_cmd) {
+void parse_dynamic_symbol_table(void *base, struct dysymtab_command *dysymtab_cmd) {
     printf("%-20s cmdsize: %-6u nlocalsym: %d  nextdefsym: %d   nundefsym: %d   nindirectsyms: %d \n",
         "LC_DYSYMTAB", dysymtab_cmd->cmdsize, dysymtab_cmd->nlocalsym,
         dysymtab_cmd->nextdefsym,  dysymtab_cmd->nundefsym, dysymtab_cmd->nindirectsyms);
@@ -32,7 +30,7 @@ void parse_dynamic_symbol_table(FILE *fptr, struct dysymtab_command *dysymtab_cm
     void *sym_table = NULL;
     void *str_table = NULL;
 
-    load_symtab_cmd(fptr, &sym_table, &str_table);
+    load_symtab_cmd(base, &sym_table, &str_table);
 
     printf("    Local symbols (ilocalsym %d, nlocalsym:%d)\n", dysymtab_cmd->ilocalsym, dysymtab_cmd->nlocalsym);
     print_symbols(sym_table, str_table, dysymtab_cmd->ilocalsym, dysymtab_cmd->nlocalsym);
@@ -47,31 +45,25 @@ void parse_dynamic_symbol_table(FILE *fptr, struct dysymtab_command *dysymtab_cm
     printf("\n");
 
     printf("    Indirect symbol table (indirectsymoff: 0x%x, nindirectsyms: %d)\n", dysymtab_cmd->indirectsymoff, dysymtab_cmd->nindirectsyms);
-    uint32_t *indirect_symtab = (uint32_t *)load_bytes(fptr, dysymtab_cmd->indirectsymoff, dysymtab_cmd->nindirectsyms * sizeof(uint32_t)); // the index is 32 bits
+    uint32_t *indirect_symtab = base + dysymtab_cmd->indirectsymoff; // the index is 32 bits
     print_indirect_symbols(sym_table, str_table, indirect_symtab, dysymtab_cmd->nindirectsyms);
-    free(indirect_symtab);
-
-    free(sym_table);
-    free(str_table);
 }
 
 
-void load_symtab_cmd(FILE *fptr, void **sym_table, void **str_table) {
-    struct mach_header_64 *header = load_bytes(fptr, 0, sizeof(struct mach_header_64));
+void load_symtab_cmd(void *base, void **sym_table, void **str_table) {
+    struct mach_header_64 *header = base;
     int offset = sizeof(struct mach_header_64);
     for (int i = 0; i < header->ncmds; ++i) {
-        struct load_command *lcmd = load_bytes(fptr, offset, sizeof(struct load_command));
+        struct load_command *lcmd = base + offset;
 
         if (lcmd->cmd == LC_SYMTAB) {
-            struct symtab_command *symtab_cmd = load_bytes(fptr, offset, lcmd->cmdsize);
-            *sym_table = load_bytes(fptr, symtab_cmd->symoff, symtab_cmd->nsyms * sizeof(struct nlist_64));
-            *str_table = load_bytes(fptr, symtab_cmd->stroff, symtab_cmd->strsize);
-            free(lcmd);
+            struct symtab_command *symtab_cmd = base + offset; // load_bytes(fptr, offset, lcmd->cmdsize);
+            *sym_table = base + symtab_cmd->symoff; //load_bytes(base, symtab_cmd->symoff, symtab_cmd->nsyms * sizeof(struct nlist_64));
+            *str_table = base + symtab_cmd->stroff; //load_bytes(base, symtab_cmd->stroff, symtab_cmd->strsize);
             return;
         }
 
         offset += lcmd->cmdsize;
-        free(lcmd);
     }
 }
 

--- a/macho_parser/sources/dysymtab.h
+++ b/macho_parser/sources/dysymtab.h
@@ -4,6 +4,6 @@
 #include <stdio.h>
 #include <mach-o/loader.h>
 
-void parse_dynamic_symbol_table(FILE *, struct dysymtab_command *);
+void parse_dynamic_symbol_table(void *base, struct dysymtab_command *);
 
 #endif /* DYSYMTAB_H */

--- a/macho_parser/sources/linkedit_data.c
+++ b/macho_parser/sources/linkedit_data.c
@@ -5,9 +5,9 @@
 #include "linkedit_data.h"
 
 static char *command_name(uint32_t cmd);
-static void parse_function_starts(FILE *fptr, uint32_t dataoff, uint32_t datasize);
+static void parse_function_starts(void *base, uint32_t dataoff, uint32_t datasize);
 
-void parse_linkedit_data(FILE *fptr, struct linkedit_data_command *linkedit_data_cmd) {
+void parse_linkedit_data(void *base, struct linkedit_data_command *linkedit_data_cmd) {
     printf("%-20s cmdsize: %-6u dataoff: 0x%x (%d)   datasize: %d\n",
         command_name(linkedit_data_cmd->cmd), linkedit_data_cmd->cmdsize,
         linkedit_data_cmd->dataoff, linkedit_data_cmd->dataoff, linkedit_data_cmd->datasize);
@@ -15,9 +15,9 @@ void parse_linkedit_data(FILE *fptr, struct linkedit_data_command *linkedit_data
     if (args.verbose == 0) { return; }
 
     if (linkedit_data_cmd->cmd == LC_FUNCTION_STARTS) {
-        parse_function_starts(fptr, linkedit_data_cmd->dataoff, linkedit_data_cmd->datasize);
+        parse_function_starts(base, linkedit_data_cmd->dataoff, linkedit_data_cmd->datasize);
     } else if (linkedit_data_cmd->cmd == LC_DYLD_CHAINED_FIXUPS) {
-        parse_chained_fixups(fptr, linkedit_data_cmd->dataoff, linkedit_data_cmd->datasize);
+        parse_chained_fixups(base, linkedit_data_cmd->dataoff, linkedit_data_cmd->datasize);
     }
 }
 
@@ -55,10 +55,10 @@ static char *command_name(uint32_t cmd) {
     return cmd_name;
 }
 
-static void parse_function_starts(FILE *fptr, uint32_t dataoff, uint32_t datasize) {
+static void parse_function_starts(void *base, uint32_t dataoff, uint32_t datasize) {
     if (!args.verbose) { return; }
 
-    uint8_t *func_starts = load_bytes(fptr, dataoff, datasize);
+    uint8_t *func_starts = base + dataoff; // load_bytes(fptr, dataoff, datasize);
 
     int i = 0;
     int address = 0;

--- a/macho_parser/sources/linkedit_data.c
+++ b/macho_parser/sources/linkedit_data.c
@@ -58,7 +58,7 @@ static char *command_name(uint32_t cmd) {
 static void parse_function_starts(void *base, uint32_t dataoff, uint32_t datasize) {
     if (!args.verbose) { return; }
 
-    uint8_t *func_starts = base + dataoff; // load_bytes(fptr, dataoff, datasize);
+    uint8_t *func_starts = base + dataoff;
 
     int i = 0;
     int address = 0;
@@ -69,8 +69,6 @@ static void parse_function_starts(void *base, uint32_t dataoff, uint32_t datasiz
         address += num;
         printf("    0x%x\n", address);
     }
-
-    free(func_starts);
 }
 
 

--- a/macho_parser/sources/linkedit_data.h
+++ b/macho_parser/sources/linkedit_data.h
@@ -4,6 +4,6 @@
 #include <stdio.h>
 #include <mach-o/loader.h>
 
-void parse_linkedit_data(FILE *, struct linkedit_data_command *);
+void parse_linkedit_data(void *base, struct linkedit_data_command *);
 
 #endif /* LINKEDIT_DATA_H */

--- a/macho_parser/sources/macho_header.c
+++ b/macho_parser/sources/macho_header.c
@@ -5,6 +5,7 @@
 #include <mach-o/swap.h>
 
 #include "util.h"
+#include "argument.h"
 
 #include "macho_header.h"
 
@@ -29,7 +30,9 @@ struct load_cmd_info parse_header(void *base) {
 
     if (magic == FAT_MAGIC || magic == FAT_CIGAM) {
         struct fat_header header = read_fat_header(base, NEEDS_SWAP(magic));
-        print_fat_header(magic, header);
+        if (show_header()) {
+            print_fat_header(magic, header);
+        }
 
         struct fat_arch *fat_archs = read_fat_archs(base, header, NEEDS_SWAP(magic));
         print_fat_archs(fat_archs, header.nfat_arch);
@@ -52,7 +55,9 @@ struct load_cmd_info parse_header(void *base) {
     }
 
     struct mach_header_64 header = read_mach_header(base, mach_header_offset);
-    print_mach_header(header);
+    if (show_header()) {
+        print_mach_header(header);
+    }
 
     struct load_cmd_info lcinfo;
     lcinfo.count = header.ncmds;

--- a/macho_parser/sources/macho_header.h
+++ b/macho_parser/sources/macho_header.h
@@ -1,7 +1,6 @@
 #ifndef MACHO_HEADER_H
 #define MACHO_HEADER_H
 
-#include <stdio.h>
 #include <mach-o/loader.h>
 
 struct load_cmd_info {
@@ -11,6 +10,6 @@ struct load_cmd_info {
     int count;
 };
 
-struct load_cmd_info parse_header(FILE *fptr);
+struct load_cmd_info parse_header(void *base);
 
 #endif /* MACHO_HEADER_H */

--- a/macho_parser/sources/main.c
+++ b/macho_parser/sources/main.c
@@ -34,18 +34,11 @@ int main(int argc, char **argv) {
         return 1;
     }
 
-    // void *base = fopen(args.file_name, "rb");
-    // if (fptr == NULL) {
-    //     fprintf(stderr, "Cannot open file %s\n", args.file_name);
-    //     return 1;
-    // }
-
     int fd;
     struct stat sb;
 
     fd = open(args.file_name, O_RDONLY);
     fstat(fd, &sb);
-    printf("Size: %llu\n", (uint64_t)sb.st_size);
 
     void *base = mmap(NULL, sb.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
     if (base == MAP_FAILED) {
@@ -57,7 +50,6 @@ int main(int argc, char **argv) {
     parse_load_commands(base, lcinfo.offset, lcinfo.count);
 
     munmap(base, sb.st_size);
-    // fclose(fptr);
     return 0;
 }
 

--- a/macho_parser/sources/segment_64.h
+++ b/macho_parser/sources/segment_64.h
@@ -1,9 +1,8 @@
 #ifndef SEGMENT_64_H
 #define SEGMENT_64_H
 
-#include <stdio.h>
 #include <mach-o/loader.h>
 
-void parse_segment(FILE *fptr, struct segment_command_64 *seg_cmd);
+void parse_segment(void *base, struct segment_command_64 *seg_cmd);
 
 #endif /* SEGMENT_64_H */

--- a/macho_parser/sources/symtab.c
+++ b/macho_parser/sources/symtab.c
@@ -5,8 +5,6 @@
 #include "argument.h"
 #include "symtab.h"
 
-extern void *load_bytes(void *base, int offset, int size);
-
 static void format_n_type(uint8_t n_type, char *formatted);
 static void format_n_desc(uint8_t n_type, uint16_t n_desc, char *formatted);
 

--- a/macho_parser/sources/symtab.c
+++ b/macho_parser/sources/symtab.c
@@ -1,23 +1,24 @@
 #include <stdlib.h>
+#include <stdio.h>
 #include <string.h>
 #include <mach-o/nlist.h>
 #include "argument.h"
 #include "symtab.h"
 
-extern void *load_bytes(FILE *fptr, int offset, int size);
+extern void *load_bytes(void *base, int offset, int size);
 
 static void format_n_type(uint8_t n_type, char *formatted);
 static void format_n_desc(uint8_t n_type, uint16_t n_desc, char *formatted);
 
-void parse_symbol_table(FILE *fptr, struct symtab_command *symtab_cmd) {
+void parse_symbol_table(void *base, struct symtab_command *symtab_cmd) {
     printf("%-20s cmdsize: %-6d symoff: %d   nsyms: %d   (symsize: %lu)   stroff: %d   strsize: %u\n",
         "LC_SYMTAB", symtab_cmd->cmdsize, symtab_cmd->symoff, symtab_cmd->nsyms,
         symtab_cmd->nsyms * sizeof(struct nlist_64), symtab_cmd->stroff, symtab_cmd->strsize);
 
     if (args.verbose == 0) { return; }
 
-    void *sym_table = load_bytes(fptr, symtab_cmd->symoff, symtab_cmd->nsyms * sizeof(struct nlist_64));
-    void *str_table = load_bytes(fptr, symtab_cmd->stroff, symtab_cmd->strsize);
+    void *sym_table = base + symtab_cmd->symoff;
+    void *str_table = base + symtab_cmd->stroff;
 
     int nsyms = symtab_cmd->nsyms;
     int max_number = args.verbose == 1 ? (nsyms > 10 ? 10 : nsyms) : nsyms;
@@ -46,9 +47,6 @@ void parse_symbol_table(FILE *fptr, struct symtab_command *symtab_cmd) {
     if (args.verbose == 1 && nsyms > 10) {
         printf("        ... %d more ...\n", nsyms - 10);
     }
-
-    free(sym_table);
-    free(str_table);
 }
 
 static void format_n_type(uint8_t n_type, char *formatted) {

--- a/macho_parser/sources/symtab.h
+++ b/macho_parser/sources/symtab.h
@@ -1,9 +1,8 @@
 #ifndef SYMTAB_H
 #define SYMTAB_H
 
-#include <stdio.h>
 #include <mach-o/loader.h>
 
-void parse_symbol_table(FILE *fptr, struct symtab_command *cmd);
+void parse_symbol_table(void *base, struct symtab_command *cmd);
 
 #endif /* SYMTAB_H */

--- a/macho_parser/sources/util.c
+++ b/macho_parser/sources/util.c
@@ -1,15 +1,15 @@
 #include "util.h"
 
-void read_bytes(FILE *fptr, int offset, void *buf, int size) {
-    fseek(fptr, offset, SEEK_SET);
-    fread(buf, size, 1, fptr);
-}
+// void read_bytes(void *base, int offset, void *buf, int size) {
+//     fseek(fptr, offset, SEEK_SET);
+//     fread(buf, size, 1, fptr);
+// }
 
-void *load_bytes(FILE *fptr, int offset, int size) {
-    void *buf = calloc(1, size);
-    read_bytes(fptr, offset, buf, size);
-    return buf;
-}
+// void *load_bytes(void *base, int offset, int size) {
+//     void *buf = calloc(1, size);
+//     read_bytes(fptr, offset, buf, size);
+//     return buf;
+// }
 
 int read_uleb128(const uint8_t *p, uint64_t *out) {
     uint64_t result = 0;

--- a/macho_parser/sources/util.c
+++ b/macho_parser/sources/util.c
@@ -1,16 +1,5 @@
 #include "util.h"
 
-// void read_bytes(void *base, int offset, void *buf, int size) {
-//     fseek(fptr, offset, SEEK_SET);
-//     fread(buf, size, 1, fptr);
-// }
-
-// void *load_bytes(void *base, int offset, int size) {
-//     void *buf = calloc(1, size);
-//     read_bytes(fptr, offset, buf, size);
-//     return buf;
-// }
-
 int read_uleb128(const uint8_t *p, uint64_t *out) {
     uint64_t result = 0;
     int i = 0;

--- a/macho_parser/sources/util.h
+++ b/macho_parser/sources/util.h
@@ -2,11 +2,6 @@
 #define UTIL_H
 
 #include <stdlib.h>
-#include <stdio.h>
-
-void read_bytes(FILE *fptr, int offset, void *buf, int size);
-
-void *load_bytes(FILE *fptr, int offset, int size);
 
 // Read a uleb128 number int to `out` and return the number of bytes processed.
 // This method assumes the input correctness and doesn't handle error cases.


### PR DESCRIPTION
Use `mmap` to map the whole file into memory for easy access.