### PR TITLE
[Build iOS App] Add swiftdeps for incremental build

### DIFF
--- a/build_ios_app/build.sh
+++ b/build_ios_app/build.sh
@@ -49,8 +49,8 @@ OUTPUT_FILE_MAP_JSON="Build/StaticLib_OutputFileMap.json"
 cat > $OUTPUT_FILE_MAP_JSON <<EOL
 {
   "": {"swift-dependencies": "Build/StaticLib-master.swiftdeps"},
-  "Sources/StaticLib/foo.swift": {"object": "Build/foo.o"},
-  "Sources/StaticLib/bar.swift": {"object": "Build/bar.o"}
+  "Sources/StaticLib/foo.swift": {"object": "Build/foo.o", "swift-dependencies": "Build/foo.swiftdeps"},
+  "Sources/StaticLib/bar.swift": {"object": "Build/bar.o", "swift-dependencies": "Build/bar.swiftdeps"}
 }
 EOL
 


### PR DESCRIPTION
Swift 5.5 compiler shows a new warning.
```
remark: Incremental compilation has been disabled: bar.swift has no swiftDeps file
remark: Incremental compilation has been disabled: foo.swift has no swiftDeps file
```