### PR TITLE
[Mach-O Parser] Parse LC_CODE_SIGNATURE

### DIFF
--- a/macho_parser/build.sh
+++ b/macho_parser/build.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Usage: build.sh --openssl
+#   --openssl    Build with OpenSSL library, enabling printing more details of code signature.
 set -e
 
 OPT_OPENSSL=0

--- a/macho_parser/build.sh
+++ b/macho_parser/build.sh
@@ -2,4 +2,4 @@
 set -e
 
 srcs=$(ls sources/*.c)
-clang -o parser $srcs
+clang -o parser -lssl -lcrypto -L/usr/local/opt/openssl/lib -framework CoreFoundation -framework Security $srcs

--- a/macho_parser/build.sh
+++ b/macho_parser/build.sh
@@ -1,5 +1,21 @@
 #!/bin/bash
 set -e
 
-srcs=$(ls sources/*.c)
-clang -o parser -lssl -lcrypto -L/usr/local/opt/openssl/lib -framework CoreFoundation -framework Security $srcs
+OPT_OPENSSL=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --openssl)
+            OPT_OPENSSL=1
+            shift
+            ;;
+    esac
+done
+
+CFLAGS=""
+
+if [ "$OPT_OPENSSL" == 1 ]; then
+    CFLAGS="$CFLAGS -lssl -lcrypto -L/usr/local/opt/openssl/lib -D OPENSSL"
+fi
+
+SRCS=$(ls sources/*.c)
+clang -o parser -framework CoreFoundation -framework Security $CFLAGS $SRCS

--- a/macho_parser/sources/argument.c
+++ b/macho_parser/sources/argument.c
@@ -63,6 +63,8 @@ unsigned int string_to_load_command(char *cmd_str) {
         return LC_DYLD_EXPORTS_TRIE;
     } else if (strcmp(cmd_str, "LC_DYLD_CHAINED_FIXUPS") == 0) {
         return LC_DYLD_CHAINED_FIXUPS;
+    } else if (strcmp(cmd_str, "LC_CODE_SIGNATURE") == 0) {
+        return LC_CODE_SIGNATURE;
     }
 
     fprintf(stderr, "Unknow load command: %s.\n", cmd_str);

--- a/macho_parser/sources/code_signature.c
+++ b/macho_parser/sources/code_signature.c
@@ -6,16 +6,21 @@
 #include <Kernel/kern/cs_blobs.h>
 
 #include "util.h"
+#include "argument.h"
 #include "code_signature.h"
 
-static void format_blob_name(uint32_t blob_type, char *formatted);
 static void print_code_directory(CS_CodeDirectory *code_directory);
+static void format_blob_name(uint32_t blob_type, char *formatted);
+static void format_blob_magic(uint32_t magic, char *formated);
 
 void parse_code_signature(void *base, uint32_t dataoff, uint32_t datasize) {
-    CS_SuperBlob *super_blob = base + dataoff;
+    char magic_name[256];
 
-    printf("SuperBlob maggic: %#x, length: %d, count: %d\n",
-        OSSwapInt32(super_blob->magic),
+    CS_SuperBlob *super_blob = base + dataoff;
+    format_blob_magic(OSSwapInt32(super_blob->magic), magic_name);
+
+    printf("SuperBlob | maggic: %s, length: %d, count: %d\n",
+        magic_name,
         OSSwapInt32(super_blob->length),
         OSSwapInt32(super_blob->count));
 
@@ -23,14 +28,15 @@ void parse_code_signature(void *base, uint32_t dataoff, uint32_t datasize) {
         uint32_t blob_type = OSSwapInt32(super_blob->index[i].type);
         uint32_t blob_offset = OSSwapInt32(super_blob->index[i].offset);
 
-        char blob_name[256];
-        format_blob_name(blob_type, blob_name);
-        printf("  Blob %d: type: %s, offset: %d\n", i, blob_name, blob_offset);
+        uint32_t magic = OSSwapInt32(*(uint32_t *)((void *)super_blob + blob_offset));
+        format_blob_magic(magic, magic_name);
 
-        if (blob_type == CSSLOT_CODEDIRECTORY) {
+        printf("  Blob %d | type: %#07x, offset: %-7d, magic: %s\n", i, blob_type, blob_offset, magic_name);
+
+        if (magic == CSMAGIC_CODEDIRECTORY) {
             CS_CodeDirectory *code_directory = (void *)super_blob + blob_offset;
             print_code_directory(code_directory);
-        } else if (blob_type == CSSLOT_ENTITLEMENTS) {
+        } else if (magic == CSMAGIC_EMBEDDED_ENTITLEMENTS) {
             CS_GenericBlob *generic_blob = (void *)super_blob + blob_offset;
             // printf("%.*s\n\n", OSSwapInt32(generic_blob->length), generic_blob->data);
         }
@@ -40,31 +46,46 @@ void parse_code_signature(void *base, uint32_t dataoff, uint32_t datasize) {
 static void print_code_directory(CS_CodeDirectory *code_directory) {
     uint32_t hash_offset = OSSwapInt32(code_directory->hashOffset);
     uint8_t hash_size = code_directory->hashSize;
+    uint32_t special_slot_size = OSSwapInt32(code_directory->nSpecialSlots);
+    uint32_t slot_size = OSSwapInt32(code_directory->nCodeSlots);
+    uint32_t identity_offset = OSSwapInt32(code_directory->identOffset);
 
     printf("    magic        : %#x\n", OSSwapInt32(code_directory->magic));
     printf("    length       : %d\n", OSSwapInt32(code_directory->length));
     printf("    version      : %#x\n", OSSwapInt32(code_directory->version));
     printf("    flags        : %#x\n", OSSwapInt32(code_directory->flags));
     printf("    hashOffset   : %d\n", hash_offset);
-    printf("    identOffset  : %d\n", OSSwapInt32(code_directory->identOffset));
-    printf("    nSpecialSlots: %d\n", OSSwapInt32(code_directory->nSpecialSlots));
+    printf("    identOffset  : %d\n", identity_offset);
+    printf("    nSpecialSlots: %d\n", special_slot_size);
     printf("    nCodeSlots   : %d\n", OSSwapInt32(code_directory->nCodeSlots));
     printf("    codeLimit    : %d\n", OSSwapInt32(code_directory->codeLimit));
     printf("    hashSize     : %d\n", hash_size);
     printf("    hashType     : %d\n", (code_directory->hashType));
     printf("    platform     : %d\n", (code_directory->platform));
     printf("    pageSize     : %d\n", (int)pow(2, code_directory->pageSize));
+    printf("    identity     : %s\n", (char *)code_directory + identity_offset);
     printf("\n");
 
     uint8_t *hash_base = (void *)code_directory + hash_offset;
     char hash[256];
-    for (int i = OSSwapInt32(code_directory->nSpecialSlots); i > 0; --i) {
+    for (int i = special_slot_size; i > 0; --i) {
         bzero(hash, sizeof(hash));
         format_hex(hash_base - i * hash_size, hash_size, hash);
-        printf("    Slot[%d] : %s\n", -i, hash);
+        printf("    Slot[%3d] : %s\n", -i, hash);
     }
 
-    printf("    signing identity: %s\n", (char *)code_directory + OSSwapInt32(code_directory->identOffset));
+    int max_number = args.verbose == 1 ? (slot_size > 10 ? 10 : slot_size) : slot_size;
+
+    for (int i = 0; i < max_number; ++i) {
+        bzero(hash, sizeof(hash));
+        format_hex(hash_base + i * hash_size, hash_size, hash);
+        printf("    Slot[%3d] : %s\n", i, hash);
+    }
+
+    if (args.verbose == 1 && slot_size > 10) {
+        printf("        ... %d more ...\n", slot_size - 10);
+    }
+    printf("\n");
 }
 
 static void format_blob_name(uint32_t blob_type, char *formatted) {
@@ -75,7 +96,21 @@ static void format_blob_name(uint32_t blob_type, char *formatted) {
         case CSSLOT_RESOURCEDIR: strcpy(formatted, "CSSLOT_RESOURCEDIR"); break;
         case CSSLOT_APPLICATION: strcpy(formatted, "CSSLOT_APPLICATION"); break;
         case CSSLOT_ENTITLEMENTS: strcpy(formatted, "CSSLOT_ENTITLEMENTS"); break;
-        // case CSSLOT_SIGNATURESLOT: strcpy(formatted, "CSSLOT_SIGNATURESLOT"); break;
+        case CSSLOT_SIGNATURESLOT: strcpy(formatted, "CSSLOT_SIGNATURESLOT"); break;
         default: sprintf(formatted, "UNKNOWN(0x%x)", blob_type);
+    }
+}
+
+static void format_blob_magic(uint32_t magic, char *formatted) {
+    switch(magic) {
+        case CSMAGIC_REQUIREMENT: strcpy(formatted, "CSMAGIC_REQUIREMENT"); break;
+        case CSMAGIC_REQUIREMENTS: strcpy(formatted, "CSMAGIC_REQUIREMENTS"); break;
+        case CSMAGIC_CODEDIRECTORY: strcpy(formatted, "CSMAGIC_CODEDIRECTORY"); break;
+        case CSMAGIC_EMBEDDED_SIGNATURE: strcpy(formatted, "CSMAGIC_EMBEDDED_SIGNATURE"); break;
+        case CSMAGIC_EMBEDDED_SIGNATURE_OLD: strcpy(formatted, "CSMAGIC_EMBEDDED_SIGNATURE_OLD"); break;
+        case CSMAGIC_EMBEDDED_ENTITLEMENTS: strcpy(formatted, "CSMAGIC_EMBEDDED_ENTITLEMENTS"); break;
+        case CSMAGIC_DETACHED_SIGNATURE: strcpy(formatted, "CSMAGIC_DETACHED_SIGNATURE"); break;
+        case CSMAGIC_BLOBWRAPPER: strcpy(formatted, "CSMAGIC_BLOBWRAPPER"); break;
+        default: sprintf(formatted, "UNKNOWN(%#08x)", magic);
     }
 }

--- a/macho_parser/sources/code_signature.c
+++ b/macho_parser/sources/code_signature.c
@@ -37,14 +37,16 @@ void parse_code_signature(void *base, uint32_t dataoff, uint32_t datasize) {
 
         printf("  Blob %d: type: %#07x, offset: %-7d, magic: %s\n", i, blob_type, blob_offset, magic_name);
 
+        if (args.verbose <= 1) {
+            continue;
+        }
+
         if (magic == CSMAGIC_CODEDIRECTORY) {
             CS_CodeDirectory *code_directory = (void *)super_blob + blob_offset;
             print_code_directory(code_directory);
         } else if (magic == CSMAGIC_EMBEDDED_ENTITLEMENTS) {
             CS_GenericBlob *generic_blob = (void *)super_blob + blob_offset;
-            if (args.verbose > 1) {
-                printf("%.*s\n\n", ntohl(generic_blob->length), generic_blob->data);
-            }
+            printf("%.*s\n\n", ntohl(generic_blob->length), generic_blob->data);
         } else if (magic == CSMAGIC_REQUIREMENTS) {
             CS_SuperBlob *req_super_blob = (void *)super_blob + blob_offset;
             for (int j = 0; j < ntohl(req_super_blob->count); ++j) {
@@ -56,10 +58,8 @@ void parse_code_signature(void *base, uint32_t dataoff, uint32_t datasize) {
             }
             printf("\n");
         } else if (magic == CSMAGIC_BLOBWRAPPER) {
-            if (args.verbose > 1) {
-                CS_GenericBlob *generic_blob = (void *)super_blob + blob_offset;
-                print_pkcs7((const unsigned char *)generic_blob->data, ntohl(generic_blob->length));
-            }
+            CS_GenericBlob *generic_blob = (void *)super_blob + blob_offset;
+            print_pkcs7((const unsigned char *)generic_blob->data, ntohl(generic_blob->length));
         }
     }
 }

--- a/macho_parser/sources/code_signature.c
+++ b/macho_parser/sources/code_signature.c
@@ -1,0 +1,48 @@
+#include <stdio.h>
+#include <string.h>
+#include <libkern/OSByteOrder.h>
+// /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Kernel.framework/Versions/A/Headers/kern/cs_blobs.h
+#include <Kernel/kern/cs_blobs.h>
+
+#include "code_signature.h"
+
+static void format_blob_name(uint32_t blob_type, char *formatted);
+
+void parse_code_signature(void *base, uint32_t dataoff, uint32_t datasize) {
+    CS_SuperBlob *super_blob = base + dataoff;
+
+    printf("    SuperBlob maggic: 0x%x, length: %d, count: %d\n",
+        OSSwapInt32(super_blob->magic),
+        OSSwapInt32(super_blob->length),
+        OSSwapInt32(super_blob->count));
+
+    for (int i = 0; i < OSSwapInt32(super_blob->count); ++i) {
+        uint32_t blob_type = OSSwapInt32(super_blob->index[i].type);
+        uint32_t blob_offset = OSSwapInt32(super_blob->index[i].offset);
+
+        char blob_name[256];
+        format_blob_name(blob_type, blob_name);
+        printf("        Blob %d: type: %s, offset: %d\n", i, blob_name, blob_offset);
+
+        if (blob_type == CSSLOT_CODEDIRECTORY) {
+            CS_CodeDirectory *code_directory = (void *)super_blob + blob_offset;
+            printf("%x\n\n", OSSwapInt32(code_directory->magic));
+        } else if (blob_type == CSSLOT_ENTITLEMENTS) {
+            CS_GenericBlob *generic_blob = (void *)super_blob + blob_offset;
+            printf("%.*s\n\n", OSSwapInt32(generic_blob->length), generic_blob->data);
+        }
+    }
+}
+
+static void format_blob_name(uint32_t blob_type, char *formatted) {
+    switch(blob_type) {
+        case CSSLOT_CODEDIRECTORY: strcpy(formatted, "CSSLOT_CODEDIRECTORY"); break;
+        case CSSLOT_INFOSLOT: strcpy(formatted, "CSSLOT_INFOSLOT"); break;
+        case CSSLOT_REQUIREMENTS: strcpy(formatted, "CSSLOT_REQUIREMENTS"); break;
+        case CSSLOT_RESOURCEDIR: strcpy(formatted, "CSSLOT_RESOURCEDIR"); break;
+        case CSSLOT_APPLICATION: strcpy(formatted, "CSSLOT_APPLICATION"); break;
+        case CSSLOT_ENTITLEMENTS: strcpy(formatted, "CSSLOT_ENTITLEMENTS"); break;
+        // case CSSLOT_SIGNATURESLOT: strcpy(formatted, "CSSLOT_SIGNATURESLOT"); break;
+        default: sprintf(formatted, "UNKNOWN(0x%x)", blob_type);
+    }
+}

--- a/macho_parser/sources/code_signature.c
+++ b/macho_parser/sources/code_signature.c
@@ -1,17 +1,20 @@
 #include <stdio.h>
 #include <string.h>
+#include <math.h>
 #include <libkern/OSByteOrder.h>
 // /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Kernel.framework/Versions/A/Headers/kern/cs_blobs.h
 #include <Kernel/kern/cs_blobs.h>
 
+#include "util.h"
 #include "code_signature.h"
 
 static void format_blob_name(uint32_t blob_type, char *formatted);
+static void print_code_directory(CS_CodeDirectory *code_directory);
 
 void parse_code_signature(void *base, uint32_t dataoff, uint32_t datasize) {
     CS_SuperBlob *super_blob = base + dataoff;
 
-    printf("    SuperBlob maggic: 0x%x, length: %d, count: %d\n",
+    printf("SuperBlob maggic: %#x, length: %d, count: %d\n",
         OSSwapInt32(super_blob->magic),
         OSSwapInt32(super_blob->length),
         OSSwapInt32(super_blob->count));
@@ -22,16 +25,46 @@ void parse_code_signature(void *base, uint32_t dataoff, uint32_t datasize) {
 
         char blob_name[256];
         format_blob_name(blob_type, blob_name);
-        printf("        Blob %d: type: %s, offset: %d\n", i, blob_name, blob_offset);
+        printf("  Blob %d: type: %s, offset: %d\n", i, blob_name, blob_offset);
 
         if (blob_type == CSSLOT_CODEDIRECTORY) {
             CS_CodeDirectory *code_directory = (void *)super_blob + blob_offset;
-            printf("%x\n\n", OSSwapInt32(code_directory->magic));
+            print_code_directory(code_directory);
         } else if (blob_type == CSSLOT_ENTITLEMENTS) {
             CS_GenericBlob *generic_blob = (void *)super_blob + blob_offset;
-            printf("%.*s\n\n", OSSwapInt32(generic_blob->length), generic_blob->data);
+            // printf("%.*s\n\n", OSSwapInt32(generic_blob->length), generic_blob->data);
         }
     }
+}
+
+static void print_code_directory(CS_CodeDirectory *code_directory) {
+    uint32_t hash_offset = OSSwapInt32(code_directory->hashOffset);
+    uint8_t hash_size = code_directory->hashSize;
+
+    printf("    magic        : %#x\n", OSSwapInt32(code_directory->magic));
+    printf("    length       : %d\n", OSSwapInt32(code_directory->length));
+    printf("    version      : %#x\n", OSSwapInt32(code_directory->version));
+    printf("    flags        : %#x\n", OSSwapInt32(code_directory->flags));
+    printf("    hashOffset   : %d\n", hash_offset);
+    printf("    identOffset  : %d\n", OSSwapInt32(code_directory->identOffset));
+    printf("    nSpecialSlots: %d\n", OSSwapInt32(code_directory->nSpecialSlots));
+    printf("    nCodeSlots   : %d\n", OSSwapInt32(code_directory->nCodeSlots));
+    printf("    codeLimit    : %d\n", OSSwapInt32(code_directory->codeLimit));
+    printf("    hashSize     : %d\n", hash_size);
+    printf("    hashType     : %d\n", (code_directory->hashType));
+    printf("    platform     : %d\n", (code_directory->platform));
+    printf("    pageSize     : %d\n", (int)pow(2, code_directory->pageSize));
+    printf("\n");
+
+    uint8_t *hash_base = (void *)code_directory + hash_offset;
+    char hash[256];
+    for (int i = OSSwapInt32(code_directory->nSpecialSlots); i > 0; --i) {
+        bzero(hash, sizeof(hash));
+        format_hex(hash_base - i * hash_size, hash_size, hash);
+        printf("    Slot[%d] : %s\n", -i, hash);
+    }
+
+    printf("    signing identity: %s\n", (char *)code_directory + OSSwapInt32(code_directory->identOffset));
 }
 
 static void format_blob_name(uint32_t blob_type, char *formatted) {

--- a/macho_parser/sources/code_signature.h
+++ b/macho_parser/sources/code_signature.h
@@ -1,0 +1,8 @@
+#ifndef CODE_SIGNATURE_H
+#define CODE_SIGNATURE_H
+
+#include <stdlib.h>
+
+void parse_code_signature(void *base, uint32_t dataoff, uint32_t datasize);
+
+#endif /* CODE_SIGNATURE_H */

--- a/macho_parser/sources/linkedit_data.c
+++ b/macho_parser/sources/linkedit_data.c
@@ -1,6 +1,7 @@
 #include "util.h"
 #include "argument.h"
 #include "chained_fixups.h"
+#include "code_signature.h"
 
 #include "linkedit_data.h"
 
@@ -18,6 +19,8 @@ void parse_linkedit_data(void *base, struct linkedit_data_command *linkedit_data
         parse_function_starts(base, linkedit_data_cmd->dataoff, linkedit_data_cmd->datasize);
     } else if (linkedit_data_cmd->cmd == LC_DYLD_CHAINED_FIXUPS) {
         parse_chained_fixups(base, linkedit_data_cmd->dataoff, linkedit_data_cmd->datasize);
+    } else if (linkedit_data_cmd->cmd == LC_CODE_SIGNATURE) {
+        parse_code_signature(base, linkedit_data_cmd->dataoff, linkedit_data_cmd->datasize);
     }
 }
 

--- a/macho_parser/sources/util.c
+++ b/macho_parser/sources/util.c
@@ -1,3 +1,5 @@
+#include <stdio.h>
+
 #include "util.h"
 
 int read_uleb128(const uint8_t *p, uint64_t *out) {
@@ -28,4 +30,10 @@ void format_string(char *str, char *formatted) {
         }
     }
     formatted[j] = '\0';
+}
+
+void format_hex(void *buffer, size_t size, char *formatted) {
+    for (int i = 0; i < size; ++i) {
+        sprintf(formatted + i * 2, "%02x", *((uint8_t *)buffer + i));
+    }
 }

--- a/macho_parser/sources/util.h
+++ b/macho_parser/sources/util.h
@@ -10,7 +10,7 @@ int read_uleb128(const uint8_t *p, uint64_t *out);
 // If the string contains '\n', replace with literal "\n".
 void format_string(char *str, char *formatted);
 
-// Format a binary buffer to hex
+// Hex dump a binary buffer.
 void format_hex(void *buffer, size_t size, char *formatted);
 
 #endif /* UTIL_H */

--- a/macho_parser/sources/util.h
+++ b/macho_parser/sources/util.h
@@ -10,4 +10,7 @@ int read_uleb128(const uint8_t *p, uint64_t *out);
 // If the string contains '\n', replace with literal "\n".
 void format_string(char *str, char *formatted);
 
+// Format a binary buffer to hex
+void format_hex(void *buffer, size_t size, char *formatted);
+
 #endif /* UTIL_H */


### PR DESCRIPTION
Parse `LC_CODE_SIGNATURE` load command of a macho file.

```
$ parser -c LC_CODE_SIGNATURE -vv SampleApp.app/SampleApp
LC_CODE_SIGNATURE    cmdsize: 16     dataoff: 0x214e0 (136416)   datasize: 20384
SuperBlob: magic: CSMAGIC_EMBEDDED_SIGNATURE, length: 7162, count: 5
  Blob 0: type: 0000000, offset: 52     , magic: CSMAGIC_CODEDIRECTORY
    length       : 1430
    version      : 0x20400
    flags        : 0
    hashOffset   : 342
    identOffset  : 88
    nSpecialSlots: 7
    nCodeSlots   : 34
    codeLimit    : 136416
    hashSize     : 32
    hashType     : 2
    platform     : 0
    pageSize     : 4096
    identity     : me.qyang.SampleApp

    Slot[ -7] : e7f1d4635ba1128f12935ec8659106d194ef48e907e3750a5263bdfc62b268f0
    ...
    Slot[ -1] : 30b3baca29fbcb0b7efa607508362edb06e2b8167e62a03b984b45745c178443
    Slot[  0] : c0797ca814fbe39341c4e34bcad4039667ae488b2bf8d45792147f822e16bc72
    Slot[  1] : 5c4478e90cd3d4c819732c715bd102aec1fbfba2604d8e7ddd6f97d86d3a2a7d
    ...

  Blob 1: type: 0x00002, offset: 1482   , magic: CSMAGIC_REQUIREMENTS
    Requirement[0]: offset: 20, length: 168
      identifier "me.qyang.SampleApp" and anchor apple generic and certificate leaf[subject.CN] = "Apple Development: yangq.nj@gmail.com (J5K827UFE4)" and certificate 1[field.1.2.840.113635.100.6.2.1] /* exists */

  Blob 2: type: 0x00005, offset: 1670   , magic: CSMAGIC_EMBEDDED_ENTITLEMENTS
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	<key>application-identifier</key>
	<string>YK72VSF9J6.me.qyang.SampleApp</string>
	<key>com.apple.developer.team-identifier</key>
	<string>YK72VSF9J6</string>
	<key>get-task-allow</key>
	<true/>
	<key>keychain-access-groups</key>
	<array>
		<string>YK72VSF9J6.me.qyang.SampleApp</string>
	</array>
</dict>
</plist>

  Blob 3: type: 0x00007, offset: 2165   , magic: UNKNOWN(0xfade7172)
  Blob 4: type: 0x10000, offset: 2370   , magic: CSMAGIC_BLOBWRAPPER
    PKCS7:
      type: pkcs7-signedData (1.2.840.113549.1.7.2)
      d.sign:
        version: 1
        md_algs:
            algorithm: sha256 (2.16.840.1.101.3.4.2.1)
            parameter: NULL
        contents:
          type: pkcs7-data (1.2.840.113549.1.7.1)
          d.data: <ABSENT>
    ......
```