### PR TITLE
[Mach-O Parser] Parse Rebase Info

### DIFF
--- a/macho_parser/README.md
+++ b/macho_parser/README.md
@@ -71,7 +71,7 @@ LC_SEGMENT_64        cmdsize: 712    segname: __TEXT         file: 0x00000000-0x
    1: 0x100003f28-0x100003f40 24B         (__TEXT,__stubs)                  type: S_SYMBOL_STUBS  offset: 16168   reserved1:  6
    2: 0x100003f40-0x100003f7a 58B         (__TEXT,__stub_helper)            type: S_REGULAR  offset: 16192
    3: 0x100003f7a-0x100003f9b 33B         (__TEXT,__cstring)                type: S_CSTRING_LITERALS  offset: 16250
-   4: 0x100003f9b-0x100003fa7 12B         (__TEXT,__objc_classname__TEXT)   type: S_CSTRING_LITERALS  offset: 16283
+   4: 0x100003f9b-0x100003fa7 12B         (__TEXT,__objc_classname)         type: S_CSTRING_LITERALS  offset: 16283
    5: 0x100003fa7-0x100003fac 5B          (__TEXT,__objc_methname)          type: S_CSTRING_LITERALS  offset: 16295
    6: 0x100003fac-0x100003fb4 8B          (__TEXT,__objc_methtype)          type: S_CSTRING_LITERALS  offset: 16300
    7: 0x100003fb4-0x100003ffc 72B         (__TEXT,__unwind_info)            type: S_REGULAR  offset: 16308
@@ -79,9 +79,9 @@ LC_SEGMENT_64        cmdsize: 552    segname: __DATA_CONST   file: 0x00004000-0x
    8: 0x100004000-0x100004010 16B         (__DATA_CONST,__got)              type: S_NON_LAZY_SYMBOL_POINTERS  offset: 16384   reserved1:  4
    9: 0x100004010-0x100004018 8B          (__DATA_CONST,__mod_init_func)    type: S_MOD_INIT_FUNC_POINTERS  offset: 16400
   10: 0x100004018-0x100004038 32B         (__DATA_CONST,__cfstring)         type: S_REGULAR  offset: 16408
-  11: 0x100004038-0x100004040 8B          (__DATA_CONST,__objc_classlist__DATA_CONST)  type: S_REGULAR  offset: 16440
-  12: 0x100004040-0x100004048 8B          (__DATA_CONST,__objc_nlclslist__DATA_CONST)  type: S_REGULAR  offset: 16448
-  13: 0x100004048-0x100004050 8B          (__DATA_CONST,__objc_imageinfo__DATA_CONST)  type: S_REGULAR  offset: 16456
+  11: 0x100004038-0x100004040 8B          (__DATA_CONST,__objc_classlist)   type: S_REGULAR  offset: 16440
+  12: 0x100004040-0x100004048 8B          (__DATA_CONST,__objc_nlclslist)   type: S_REGULAR  offset: 16448
+  13: 0x100004048-0x100004050 8B          (__DATA_CONST,__objc_imageinfo)   type: S_REGULAR  offset: 16456
 LC_SEGMENT_64        cmdsize: 392    segname: __DATA         file: 0x00008000-0x0000c000 16.00KB    vm: 0x100008000-0x10000c000 16.00KB   prot: 3/3
   14: 0x100008000-0x100008020 32B         (__DATA,__la_symbol_ptr)          type: S_LAZY_SYMBOL_POINTERS  offset: 32768   reserved1:  6
   15: 0x100008020-0x1000080d0 176B        (__DATA,__objc_const)             type: S_REGULAR  offset: 32800

--- a/macho_parser/README.md
+++ b/macho_parser/README.md
@@ -100,9 +100,37 @@ LC_DYLD_INFO_ONLY    cmdsize: 48     export_size: 192
   lazy_bind_off: 49360        lazy_bind_size: 80
   export_off   : 49440        export_size   : 192
 ```
+### Rebase
+```
+$ ./macho_parser --rebase sample.out
+  Rebase Table:
+__DATA_CONST,__mod_init_func      0x100004010  pointer  value(0x100003E70)
+__DATA_CONST,__cfstring           0x100004028  pointer  value(0x100003F89)
+__DATA_CONST,__objc_classlist     0x100004038  pointer  value(0x1000080F8)
+__DATA_CONST,__objc_nlclslist     0x100004040  pointer  value(0x1000080F8)
+__DATA,__la_symbol_ptr            0x100008000  pointer  value(0x100003F70)
+__DATA,__la_symbol_ptr            0x100008008  pointer  value(0x100003F40)
+__DATA,__la_symbol_ptr            0x100008010  pointer  value(0x100003F5C)
+__DATA,__la_symbol_ptr            0x100008018  pointer  value(0x100003F66)
+...
+```
+```
+$ ./macho_parser --rebase --opcode sample.out
+  Rebase Opcodes:
+0x0000 REBASE_OPCODE_SET_TYPE_IMM (REBASE_TYPE_POINTER)
+0x0001 REBASE_OPCODE_SET_SEGMENT_AND_OFFSET_ULEB (2, 0x00000010) -- __DATA_CONST
+0x0003 REBASE_OPCODE_DO_REBASE_ADD_ADDR_ULEB (0x00000010)
+0x0005 REBASE_OPCODE_DO_REBASE_ADD_ADDR_ULEB (0x00000008)
+0x0007 REBASE_OPCODE_DO_REBASE_IMM_TIMES (2)
+0x0008 REBASE_OPCODE_SET_SEGMENT_AND_OFFSET_ULEB (3, 0x00000000) -- __DATA
+0x000A REBASE_OPCODE_DO_REBASE_IMM_TIMES (4)
+0x000B REBASE_OPCODE_ADD_ADDR_IMM_SCALED (1)
+...
+```
+
 ### Bind / Lazy Bind / Weak Bind
 ```
-$ ./macho_parser --bind sample.out
+$ ./macho_parser --bind [--lazy-bind] [--weak-bind] sample.out
   Binding Table:
 __DATA_CONST,__got        0x100004000  pointer  flat-namespace        addend(0)  _c_extern_weak_function (weak import)
 __DATA_CONST,__got        0x100004008  pointer  libSystem.B.dylib     addend(0)  dyld_stub_binder

--- a/macho_parser/sources/dyld_info.cpp
+++ b/macho_parser/sources/dyld_info.cpp
@@ -106,13 +106,11 @@ static void printRebaseTable(uint8_t *base, uint32_t offset, uint32_t size) {
         uint64_t address = segCmd->vmaddr + segmentOffset;
 
         struct section_64 *sect = machoBinary.getSectionByAddress(address);
-        char *sectName = NULL;
-        if (sect != NULL) {
-            sectName = sect->sectname;
-        }
 
-        std::string sectName2 = std::string(segCmd->segname) + "," + sectName;
-        printf("%-32s  0x%llX  ", sectName2.c_str(), address);
+        char segSectName[128];
+        snprintf(segSectName, sizeof(segSectName), "%.16s,%.16s", segCmd->segname, sect ? sect->sectname : "(no section)");
+
+        printf("%-32s  0x%llX  ", segSectName, address);
 
         printf("%s  value(0x%08llX)\n", stringifyRebaseTypeImmForTable(type).c_str(),
             *(uint64_t *)(base + segCmd->fileoff + segmentOffset));
@@ -259,13 +257,10 @@ static void printBindingTable(uint8_t *base, uint32_t offset, uint32_t size, enu
         uint64_t address = segCmd->vmaddr + segmentOffset;
 
         struct section_64 *sect = machoBinary.getSectionByAddress(address);
-        char *sectName = NULL;
-        if (sect != NULL) {
-            sectName = sect->sectname;
-        }
+        char segSectName[128];
+        snprintf(segSectName, sizeof(segSectName), "%.16s,%.16s", segCmd->segname, sect ? sect->sectname : "(no section)");
 
-        std::string sectName2 = std::string(segCmd->segname) + "," + sectName;
-        printf("%-24s  0x%llX  ", sectName2.c_str(), address);
+        printf("%-24s  0x%llX  ", segSectName, address);
 
         switch (bindType) {
             case regular:

--- a/macho_parser/sources/segment_64.c
+++ b/macho_parser/sources/segment_64.c
@@ -26,7 +26,7 @@ void parse_segment(void *base, struct segment_command_64 *seg_cmd, int section_i
     format_size(seg_cmd->filesize, formatted_filesize);
     format_size(seg_cmd->vmsize, formatted_vmsize);
 
-    printf("%-20s cmdsize: %-6d segname: %-12s   file: 0x%08llx-0x%08llx %-9s  vm: 0x%09llx-0x%09llx %-9s prot: %d/%d\n",
+    printf("%-20s cmdsize: %-6d segname: %-12.16s   file: 0x%08llx-0x%08llx %-9s  vm: 0x%09llx-0x%09llx %-9s prot: %d/%d\n",
         "LC_SEGMENT_64", seg_cmd->cmdsize, seg_cmd->segname,
         seg_cmd->fileoff, seg_cmd->fileoff + seg_cmd->filesize, formatted_filesize,
         seg_cmd->vmaddr, seg_cmd->vmaddr + seg_cmd->vmsize, formatted_vmsize,
@@ -64,7 +64,7 @@ static void print_section(void *base, struct section_64 sect, int section_index)
     const uint8_t type = sect.flags & SECTION_TYPE;
 
     format_section_type(type, formatted_type);
-    sprintf(formatted_seg_sec, "(%s,%s)", sect.segname, sect.sectname);
+    sprintf(formatted_seg_sec, "(%.16s,%.16s)", sect.segname, sect.sectname);
     format_size(sect.size, formatted_size);
 
     printf("  %2d: 0x%09llx-0x%09llx %-11s %-32s  type: %s  offset: %d",


### PR DESCRIPTION
Parse rebase info in LC_DYLD_INFO.

```
$ ./macho_parser --rebase sample.out
  Rebase Table:
__DATA_CONST,__mod_init_func      0x100004010  pointer  value(0x100003E70)
__DATA_CONST,__cfstring           0x100004028  pointer  value(0x100003F89)
__DATA_CONST,__objc_classlist     0x100004038  pointer  value(0x1000080F8)
__DATA_CONST,__objc_nlclslist     0x100004040  pointer  value(0x1000080F8)
__DATA,__la_symbol_ptr            0x100008000  pointer  value(0x100003F70)
__DATA,__la_symbol_ptr            0x100008008  pointer  value(0x100003F40)
__DATA,__la_symbol_ptr            0x100008010  pointer  value(0x100003F5C)
__DATA,__la_symbol_ptr            0x100008018  pointer  value(0x100003F66)
...
```
```
$ ./macho_parser --rebase --opcode sample.out
  Rebase Opcodes:
0x0000 REBASE_OPCODE_SET_TYPE_IMM (REBASE_TYPE_POINTER)
0x0001 REBASE_OPCODE_SET_SEGMENT_AND_OFFSET_ULEB (2, 0x00000010) -- __DATA_CONST
0x0003 REBASE_OPCODE_DO_REBASE_ADD_ADDR_ULEB (0x00000010)
0x0005 REBASE_OPCODE_DO_REBASE_ADD_ADDR_ULEB (0x00000008)
0x0007 REBASE_OPCODE_DO_REBASE_IMM_TIMES (2)
0x0008 REBASE_OPCODE_SET_SEGMENT_AND_OFFSET_ULEB (3, 0x00000000) -- __DATA
0x000A REBASE_OPCODE_DO_REBASE_IMM_TIMES (4)
0x000B REBASE_OPCODE_ADD_ADDR_IMM_SCALED (1)
...
```