### PR TITLE
[Mach-O Parser] Support parsing static library

### DIFF
--- a/macho_parser/sources/ar_parser.cpp
+++ b/macho_parser/sources/ar_parser.cpp
@@ -7,24 +7,24 @@
 
 // This file handles parsing archive (static library) format
 
-bool isArchive(uint8_t *fileBase) {
-    return strncmp(ARMAG,(char *)fileBase, strlen(ARMAG)) == 0;
+bool Archive::isArchive(uint8_t *fileBase, uint32_t fileSize) {
+    return fileSize >= strlen(ARMAG) && strncmp(ARMAG,(char *)fileBase, strlen(ARMAG)) == 0;
 }
 
-void enumerateObjectFileInArchive(uint8_t *archiveBase, size_t fileSize, std::function<void(char*, uint8_t*)> const& handler) {
-    assert(isArchive(archiveBase));
+void Archive::enumerateObjectFileInArchive(uint8_t *fileBase, uint32_t fileSize, std::function<void(char*, uint8_t*)> const& handler) {
+    assert(isArchive(fileBase, fileSize));
 
     uint32_t offset = strlen(ARMAG);
     while (offset < fileSize) {
-        struct ar_hdr *metadata = (struct ar_hdr *)(archiveBase + offset);
+        struct ar_hdr *metadata = (struct ar_hdr *)(fileBase + offset);
         assert(strncmp(ARFMAG, metadata->ar_fmag, strlen(ARFMAG)) == 0);
         offset += sizeof(struct ar_hdr);
 
-        char *fileName = metadata->ar_name;
+        char *objectFileName = metadata->ar_name;
         int efmtSize = 0;
-        if (strncmp(AR_EFMT1, fileName, strlen(AR_EFMT1)) == 0) {
-            efmtSize = atoi((char *)(fileName + strlen(AR_EFMT1)));
-            fileName = (char *)(archiveBase + offset);
+        if (strncmp(AR_EFMT1, objectFileName, strlen(AR_EFMT1)) == 0) {
+            efmtSize = atoi((char *)(objectFileName + strlen(AR_EFMT1)));
+            objectFileName = (char *)(fileBase + offset);
         }
 
         int fileSize = atoi(metadata->ar_size);
@@ -32,9 +32,9 @@ void enumerateObjectFileInArchive(uint8_t *archiveBase, size_t fileSize, std::fu
         // The first member in a static archive library is always the symbol table describing the contents of the rest of the member files.
         // It's always called __.SYMDEF or __.SYMDEF SORTED. We just skip this.
         // http://mirror.informatimago.com/next/developer.apple.com/documentation/DeveloperTools/Conceptual/MachORuntime/8rt_file_format/chapter_10_section_33.html
-        if (strncmp("__.SYMDEF", fileName, strlen("__.SYMDEF")) != 0
-            && strncmp("__.SYMDEF SORTED", fileName, strlen("__.SYMDEF SORTED")) != 0) {
-            handler(fileName, archiveBase + offset + efmtSize);
+        if (strncmp("__.SYMDEF", objectFileName, strlen("__.SYMDEF")) != 0
+            && strncmp("__.SYMDEF SORTED", objectFileName, strlen("__.SYMDEF SORTED")) != 0) {
+            handler(objectFileName, fileBase + offset + efmtSize);
         }
 
         offset += fileSize;

--- a/macho_parser/sources/ar_parser.cpp
+++ b/macho_parser/sources/ar_parser.cpp
@@ -1,0 +1,42 @@
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <ar.h>
+
+#include "ar_parser.h"
+
+// This file handles parsing archive (static library) format
+
+bool isArchive(uint8_t *fileBase) {
+    return strncmp(ARMAG,(char *)fileBase, strlen(ARMAG)) == 0;
+}
+
+void enumerateObjectFileInArchive(uint8_t *archiveBase, size_t fileSize, std::function<void(char*, uint8_t*)> const& handler) {
+    assert(isArchive(archiveBase));
+
+    uint32_t offset = strlen(ARMAG);
+    while (offset < fileSize) {
+        struct ar_hdr *metadata = (struct ar_hdr *)(archiveBase + offset);
+        assert(strncmp(ARFMAG, metadata->ar_fmag, strlen(ARFMAG)) == 0);
+        offset += sizeof(struct ar_hdr);
+
+        char *fileName = metadata->ar_name;
+        int efmtSize = 0;
+        if (strncmp(AR_EFMT1, fileName, strlen(AR_EFMT1)) == 0) {
+            efmtSize = atoi((char *)(fileName + strlen(AR_EFMT1)));
+            fileName = (char *)(archiveBase + offset);
+        }
+
+        int fileSize = atoi(metadata->ar_size);
+
+        // The first member in a static archive library is always the symbol table describing the contents of the rest of the member files.
+        // It's always called __.SYMDEF or __.SYMDEF SORTED. We just skip this.
+        // http://mirror.informatimago.com/next/developer.apple.com/documentation/DeveloperTools/Conceptual/MachORuntime/8rt_file_format/chapter_10_section_33.html
+        if (strncmp("__.SYMDEF", fileName, strlen("__.SYMDEF")) != 0
+            && strncmp("__.SYMDEF SORTED", fileName, strlen("__.SYMDEF SORTED")) != 0) {
+            handler(fileName, archiveBase + offset + efmtSize);
+        }
+
+        offset += fileSize;
+    }
+}

--- a/macho_parser/sources/ar_parser.h
+++ b/macho_parser/sources/ar_parser.h
@@ -1,0 +1,10 @@
+#ifndef AR_PARSER_H
+#define AR_PARSER_H
+
+#include <stdio.h>
+#include <functional>
+
+bool isArchive(uint8_t *fileBase);
+void enumerateObjectFileInArchive(uint8_t *archiveBase, size_t fileSize, std::function<void(char*, uint8_t*)> const& handler);
+
+#endif /* AR_PARSER_H */

--- a/macho_parser/sources/ar_parser.h
+++ b/macho_parser/sources/ar_parser.h
@@ -4,7 +4,9 @@
 #include <stdio.h>
 #include <functional>
 
-bool isArchive(uint8_t *fileBase);
-void enumerateObjectFileInArchive(uint8_t *archiveBase, size_t fileSize, std::function<void(char*, uint8_t*)> const& handler);
+namespace Archive {
+bool isArchive(uint8_t *fileBase, uint32_t fileSize);
+void enumerateObjectFileInArchive(uint8_t *archiveBase, uint32_t fileSize, std::function<void(char*, uint8_t*)> const& handler);
+}
 
 #endif /* AR_PARSER_H */

--- a/macho_parser/sources/macho_header.h
+++ b/macho_parser/sources/macho_header.h
@@ -2,6 +2,12 @@
 #define MACHO_HEADER_H
 
 #include <mach-o/loader.h>
+#include <tuple>
+
+namespace FatMacho {
+bool isFatMacho(uint8_t *fileBase, size_t fileSize);
+std::tuple<uint8_t*, uint32_t> getSliceByArch(uint8_t *fileBase, size_t fileSize, char *arch);
+}
 
 struct mach_header_64 *parseMachHeader(uint8_t *base);
 

--- a/macho_parser/sources/main.cpp
+++ b/macho_parser/sources/main.cpp
@@ -26,6 +26,7 @@ extern "C" {
 #include "dyld_info.h"
 #include "encryption_info.h"
 #include "small_cmds.h"
+#include "ar_parser.h"
 
 static void printMacho(uint8_t *machoBase);
 static void printLoadCommands(uint8_t *base, std::vector<struct load_command *> allLoadCommands);
@@ -47,7 +48,15 @@ int main(int argc, char **argv) {
         return 1;
     }
 
-    printMacho(fileBase);
+    if (isArchive(fileBase)) { // handle static library
+        enumerateObjectFileInArchive(fileBase, sb.st_size, [](char *fileName, uint8_t *fileBase) {
+            printf("\033[0;34m%s:\033[0m\n", fileName);
+            printMacho(fileBase);
+            printf("\n");
+        });
+    } else {
+        printMacho(fileBase);
+    }
 
     munmap(fileBase, sb.st_size);
     return 0;

--- a/macho_parser/sources/main.cpp
+++ b/macho_parser/sources/main.cpp
@@ -49,9 +49,9 @@ int main(int argc, char **argv) {
     }
 
     if (isArchive(fileBase)) { // handle static library
-        enumerateObjectFileInArchive(fileBase, sb.st_size, [](char *fileName, uint8_t *fileBase) {
-            printf("\033[0;34m%s:\033[0m\n", fileName);
-            printMacho(fileBase);
+        enumerateObjectFileInArchive(fileBase, sb.st_size, [](char *objectFileName, uint8_t *objectFileBase) {
+            printf("\033[0;34m%s:\033[0m\n", objectFileName);
+            printMacho(objectFileBase);
             printf("\n");
         });
     } else {
@@ -66,8 +66,9 @@ static void printMacho(uint8_t *machoBase) {
     struct mach_header_64 *machHeader = parseMachHeader(machoBase);
     // the base address of a specific arch slice
     uint8_t *base = (uint8_t *)machHeader;
-    static std::vector<struct load_command *> allLoadCommands = parseLoadCommands(base, sizeof(struct mach_header_64), machHeader->ncmds);
+    std::vector<struct load_command *> allLoadCommands = parseLoadCommands(base, sizeof(struct mach_header_64), machHeader->ncmds);
 
+    memset(&machoBinary, 0x0, sizeof(machoBinary));
     machoBinary.base = base;
     machoBinary.allLoadCommands = allLoadCommands;
 

--- a/macho_parser/sources/main.cpp
+++ b/macho_parser/sources/main.cpp
@@ -27,6 +27,7 @@ extern "C" {
 #include "encryption_info.h"
 #include "small_cmds.h"
 
+static void printMacho(uint8_t *machoBase);
 static void printLoadCommands(uint8_t *base, std::vector<struct load_command *> allLoadCommands);
 
 struct MachoBinary machoBinary;
@@ -46,7 +47,14 @@ int main(int argc, char **argv) {
         return 1;
     }
 
-    struct mach_header_64 *machHeader = parseMachHeader(fileBase);
+    printMacho(fileBase);
+
+    munmap(fileBase, sb.st_size);
+    return 0;
+}
+
+static void printMacho(uint8_t *machoBase) {
+    struct mach_header_64 *machHeader = parseMachHeader(machoBase);
     // the base address of a specific arch slice
     uint8_t *base = (uint8_t *)machHeader;
     static std::vector<struct load_command *> allLoadCommands = parseLoadCommands(base, sizeof(struct mach_header_64), machHeader->ncmds);
@@ -62,9 +70,6 @@ int main(int argc, char **argv) {
         [](struct load_command * lcmd){ return (struct segment_command_64 *)lcmd; });
 
     printLoadCommands(base, allLoadCommands);
-
-    munmap(base, sb.st_size);
-    return 0;
 }
 
 static void printLoadCommands(uint8_t *base, std::vector<struct load_command *> allLoadCommands) {


### PR DESCRIPTION
```
$ macho_parser StaticLib.a
foo.o:
MACHO_HEADER         magic: MH_MAGIC_64   cputype: X86_64   cpusubtype: ALL   filetype: OBJECT   ncmds: 9   sizeofcmds: 1568
                     flags: SUBSECTIONS_VIA_SYMBOLS
LC_SEGMENT_64        cmdsize: 1272   segname:                file: 0x00000640-0x00000cea 1.67KB     vm: 0x000000000-0x0000006aa 1.67KB    prot: 7/7
LC_BUILD_VERSION     cmdsize: 24     platform: IOSSIMULATOR   minos: 14.0.0   sdk: 15.2.0
LC_SYMTAB            cmdsize: 24     symoff: 3352   nsyms: 5   (symsize: 80)   stroff: 3432   strsize: 200
LC_DYSYMTAB          cmdsize: 80     nlocalsym: 1  nextdefsym: 3   nundefsym: 1   nindirectsyms: 0
...

bar.o:
MACHO_HEADER         magic: MH_MAGIC_64   cputype: X86_64   cpusubtype: ALL   filetype: OBJECT   ncmds: 9   sizeofcmds: 2288
                     flags: SUBSECTIONS_VIA_SYMBOLS
LC_SEGMENT_64        cmdsize: 1992   segname:                file: 0x00000910-0x00001b71 4.59KB     vm: 0x000000000-0x000001280 4.62KB    prot: 7/7
LC_BUILD_VERSION     cmdsize: 24     platform: IOSSIMULATOR   minos: 14.0.0   sdk: 15.2.0
LC_SYMTAB            cmdsize: 24     symoff: 7672   nsyms: 43   (symsize: 688)   stroff: 8360   strsize: 1264
LC_DYSYMTAB          cmdsize: 80     nlocalsym: 11  nextdefsym: 18   nundefsym: 14   nindirectsyms: 0
...
```