### PR TITLE
[Macho Parser] Parse `__llvm_covmap` section

### DIFF
--- a/macho_parser/BUILD.bazel
+++ b/macho_parser/BUILD.bazel
@@ -9,6 +9,7 @@ cc_binary(
         "sources",
     ],
     linkopts = [
+        "-lz",
         "-framework",
         "CoreFoundation",
         "-framework",

--- a/macho_parser/docs/LC_SEGMENT_64.md
+++ b/macho_parser/docs/LC_SEGMENT_64.md
@@ -88,3 +88,11 @@ The difference between `+load` and `__mod_init_func` is that the former guarante
 
 ## __LINKEDIT
 `__LINKEDIT` segment contains data that's used by the linker. Unlike other segments, this one doesn't have sections. Its contents are described by other load commands, e.g. `LC_SYMTAB`, `LC_DYSYMTAB`.
+
+## __LLVM_COV
+`__LINKEDIT` is used for code coverage.
+
+### __llvm_covfun
+
+### __llvm_covmap
+See [CoverageMapping.h](https://github.com/llvm/llvm-project/blob/main/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h)

--- a/macho_parser/sources/llvm_cov.cpp
+++ b/macho_parser/sources/llvm_cov.cpp
@@ -10,8 +10,8 @@ extern "C"
 }
 
 size_t printCovMapHeader(uint8_t *covMapBase);
-size_t printFilenamesRegion(u_int8_t *filenamesBase);
-void printFilenames(u_int8_t *uncompressedFileNames, int numFilenames);
+size_t printFilenamesRegion(uint8_t *filenamesBase);
+void printFilenames(uint8_t *uncompressedFileNames, int numFilenames);
 
 // https://llvm.org/docs/CoverageMappingFormat.html
 

--- a/macho_parser/sources/llvm_cov.cpp
+++ b/macho_parser/sources/llvm_cov.cpp
@@ -1,13 +1,8 @@
 #include <stdio.h>
 #include <iostream>
 
-#include "utils/compression.h"
+#include "utils/utils.h"
 #include "llvm_cov.h"
-
-extern "C"
-{
-  #include "util.h"
-}
 
 size_t printCovMapHeader(uint8_t *covMapBase);
 size_t printFilenamesRegion(uint8_t *filenamesBase);
@@ -48,9 +43,9 @@ size_t printFilenamesRegion(uint8_t *filenamesBase) {
 
     size_t offset = 0;
 
-    offset += read_uleb128(filenamesBase + offset, &numFilenames);
-    offset += read_uleb128(filenamesBase + offset, &uncompressedLength);
-    offset += read_uleb128(filenamesBase + offset, &compressedLength);
+    offset += readULEB128(filenamesBase + offset, &numFilenames);
+    offset += readULEB128(filenamesBase + offset, &uncompressedLength);
+    offset += readULEB128(filenamesBase + offset, &compressedLength);
 
     printf("    Filenames: (NFilenames: %llu, UncompressedLen: %llu, CompressedLen: %llu)\n", numFilenames, uncompressedLength, compressedLength);
 
@@ -75,7 +70,7 @@ void printFilenames(uint8_t *uncompressedFileNames, int numFilenames) {
     int offset = 0;
     for (int i = 0; i < numFilenames; i++) {
         uint64_t filenameLength = 0;
-        offset += read_uleb128(uncompressedFileNames + offset, &filenameLength);
+        offset += readULEB128(uncompressedFileNames + offset, &filenameLength);
 
         printf("     %2d: %.*s\n", i, (int)filenameLength, uncompressedFileNames + offset);
         offset += filenameLength;

--- a/macho_parser/sources/llvm_cov.cpp
+++ b/macho_parser/sources/llvm_cov.cpp
@@ -1,0 +1,83 @@
+#include <stdio.h>
+#include <iostream>
+
+#include "utils/compression.h"
+#include "llvm_cov.h"
+
+extern "C"
+{
+  #include "util.h"
+}
+
+size_t printCovMapHeader(uint8_t *covMapBase);
+size_t printFilenamesRegion(u_int8_t *filenamesBase);
+void printFilenames(u_int8_t *uncompressedFileNames, int numFilenames);
+
+// https://llvm.org/docs/CoverageMappingFormat.html
+
+void printCovMapSection(uint8_t *base, struct section_64 *sect) {
+    uint8_t *covMapBase = base + sect->offset;
+
+    size_t offset = 0;
+    while (offset < sect->size) {
+        printf("\n");
+        offset += printCovMapHeader(covMapBase + offset);
+        offset += printFilenamesRegion(covMapBase + offset);
+    }
+}
+
+// https://github.com/apple/llvm-project/blob/4305e61a0d81cc071a88090fa8579440c2220e07/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h#L990-L1007
+size_t printCovMapHeader(uint8_t *covMapBase) {
+    uint32_t * header = (uint32_t *)covMapBase;
+    // https://github.com/apple/llvm-project/blob/4305e61a0d81cc071a88090fa8579440c2220e07/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h#L1011-L1029
+    uint32_t version = header[3] + 1;
+    printf("CovMap Header: (NRecords: %d, FilenamesSize: %d, CoverageSize: %d, Version: %d)\n", header[0], header[1], header[2], version);
+
+    if (version < 4) {
+        std::cerr << "Coverage map version lower than 4 is not supported." << std::endl;
+        exit(1);
+    }
+
+    return 4 * 4; // CovMap header size
+}
+
+size_t printFilenamesRegion(uint8_t *filenamesBase) {
+    uint64_t numFilenames = 0;
+    uint64_t uncompressedLength = 0;
+    uint64_t compressedLength = 0;
+
+    size_t offset = 0;
+
+    offset += read_uleb128(filenamesBase + offset, &numFilenames);
+    offset += read_uleb128(filenamesBase + offset, &uncompressedLength);
+    offset += read_uleb128(filenamesBase + offset, &compressedLength);
+
+    printf("    Filenames: (NFilenames: %llu, UncompressedLen: %llu, CompressedLen: %llu)\n", numFilenames, uncompressedLength, compressedLength);
+
+    uint8_t *uncompressedData = (uint8_t *)malloc(uncompressedLength);;
+    if (compressedLength > 0) {
+        decompressZlibData(filenamesBase + offset, compressedLength, uncompressedData, uncompressedLength);
+        offset += compressedLength;
+    } else {
+        memcpy(uncompressedData, filenamesBase + offset, uncompressedLength);
+        offset += uncompressedLength;
+    }
+
+    printFilenames(uncompressedData, numFilenames);
+
+    free(uncompressedData);
+
+    // Each coverage map has an alignment of 8 bytes
+    return (offset + 7) / 8 * 8;
+}
+
+void printFilenames(uint8_t *uncompressedFileNames, int numFilenames) {
+    int offset = 0;
+    for (int i = 0; i < numFilenames; i++) {
+        uint64_t filenameLength = 0;
+        offset += read_uleb128(uncompressedFileNames + offset, &filenameLength);
+
+        printf("     %2d: %.*s\n", i, (int)filenameLength, uncompressedFileNames + offset);
+        offset += filenameLength;
+    }
+}

--- a/macho_parser/sources/llvm_cov.h
+++ b/macho_parser/sources/llvm_cov.h
@@ -1,0 +1,16 @@
+#ifndef MACHO_PARSER_COVERAGE_H
+#define MACHO_PARSER_COVERAGE_H
+
+#include <mach-o/loader.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void printCovMapSection(uint8_t *base, struct section_64 *sect);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MACHO_PARSER_COVERAGE_H */

--- a/macho_parser/sources/segment_64.c
+++ b/macho_parser/sources/segment_64.c
@@ -7,6 +7,7 @@
 #include "symtab.h"
 
 #include "segment_64.h"
+#include "llvm_cov.h"
 
 static void print_section(void *base, struct section_64 sect, int section_index);
 static void print_cstring_section(void *base, struct section_64 *sect);
@@ -86,8 +87,12 @@ static void print_section(void *base, struct section_64 sect, int section_index)
         return;
     }
 
+    if (strncmp(sect.sectname, "__llvm_covmap", 16) == 0) {
+        printCovMapSection(base, &sect);
+    }
     // (__TEXT,__cstring), (__TEXT,__objc_classname__TEXT), (__TEXT,__objc_methname), etc..
-    if (type == S_CSTRING_LITERALS) {
+    else if (type == S_CSTRING_LITERALS) {
+
         print_cstring_section(base, &sect);
     }
     // (__DATA_CONST,__mod_init_func)

--- a/macho_parser/sources/utils/compression.cpp
+++ b/macho_parser/sources/utils/compression.cpp
@@ -1,0 +1,29 @@
+#include <zlib.h>
+#include <iostream>
+
+// This function is mostly written by ChatGPT.
+void decompressZlibData(u_int8_t* inputData, size_t inputSize, u_int8_t* outputData, size_t outputSize) {
+    z_stream strm;
+    strm.zalloc = Z_NULL;
+    strm.zfree = Z_NULL;
+    strm.opaque = Z_NULL;
+    strm.avail_in = inputSize;
+    strm.next_in = (Bytef*)inputData;
+    strm.avail_out = outputSize;
+    strm.next_out = (Bytef*)outputData;
+
+    int ret = inflateInit(&strm);
+    if (ret != Z_OK) {
+        std::cerr << "Error initializing zlib inflate: " << ret << std::endl;
+        return;
+    }
+
+    ret = inflate(&strm, Z_FINISH);
+    if (ret != Z_STREAM_END) {
+        std::cerr << "Error decompressing zlib data: " << ret << std::endl;
+        inflateEnd(&strm);
+        return;
+    }
+
+    inflateEnd(&strm);
+}

--- a/macho_parser/sources/utils/compression.cpp
+++ b/macho_parser/sources/utils/compression.cpp
@@ -2,7 +2,7 @@
 #include <iostream>
 
 // This function is mostly written by ChatGPT.
-void decompressZlibData(u_int8_t* inputData, size_t inputSize, u_int8_t* outputData, size_t outputSize) {
+void decompressZlibData(const uint8_t *inputData, size_t inputSize, uint8_t *outputData, size_t outputSize) {
     z_stream strm;
     strm.zalloc = Z_NULL;
     strm.zfree = Z_NULL;

--- a/macho_parser/sources/utils/compression.cpp
+++ b/macho_parser/sources/utils/compression.cpp
@@ -1,6 +1,8 @@
 #include <zlib.h>
 #include <iostream>
 
+#include "utils.h"
+
 // This function is mostly written by ChatGPT.
 void decompressZlibData(const uint8_t *inputData, size_t inputSize, uint8_t *outputData, size_t outputSize) {
     z_stream strm;

--- a/macho_parser/sources/utils/compression.h
+++ b/macho_parser/sources/utils/compression.h
@@ -1,7 +1,0 @@
-#ifndef MACHO_PARSER_COMPRESSION_H
-#define MACHO_PARSER_COMPRESSION_H
-
-// Decompress that data using zlib.
-void decompressZlibData(const uint8_t *inputData, size_t inputSize, uint8_t *outputData, size_t outputSize);
-
-#endif /* MACHO_PARSER_COMPRESSION_H */

--- a/macho_parser/sources/utils/compression.h
+++ b/macho_parser/sources/utils/compression.h
@@ -2,6 +2,6 @@
 #define MACHO_PARSER_COMPRESSION_H
 
 // Decompress that data using zlib.
-void decompressZlibData(u_int8_t* inputData, size_t inputSize, u_int8_t* outputData, size_t outputSize);
+void decompressZlibData(const uint8_t *inputData, size_t inputSize, uint8_t *outputData, size_t outputSize);
 
 #endif /* MACHO_PARSER_COMPRESSION_H */

--- a/macho_parser/sources/utils/compression.h
+++ b/macho_parser/sources/utils/compression.h
@@ -1,0 +1,7 @@
+#ifndef MACHO_PARSER_COMPRESSION_H
+#define MACHO_PARSER_COMPRESSION_H
+
+// Decompress that data using zlib.
+void decompressZlibData(u_int8_t* inputData, size_t inputSize, u_int8_t* outputData, size_t outputSize);
+
+#endif /* MACHO_PARSER_COMPRESSION_H */

--- a/macho_parser/sources/utils/utils.h
+++ b/macho_parser/sources/utils/utils.h
@@ -15,6 +15,9 @@ int readULEB128(const uint8_t *p, uint64_t *out);
 // This method assumes the input correctness and doesn't handle error cases.
 int readSLEB128(const uint8_t *p, int64_t *out);
 
+// Decompress that data using zlib.
+void decompressZlibData(const uint8_t *inputData, size_t inputSize, uint8_t *outputData, size_t outputSize);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Support parsing `__LLVM_COV,__llvm_covmap` section. This section contains multiple coverage mapping data, one per each compilation unit. Essentially this section contains file names that are used for code coverage.

#### Sample output of macho parser:
```
CovMap Header: (NRecords: 0, FilenamesSize: 66, CoverageSize: 0, Version: 6)
    Filenames: (NFilenames: 1, UncompressedLen: 72, CompressedLen: 63)
      0: ./ios/foundations/StringFoundation/Tests/StringRepresentableTests.swift

CovMap Header: (NRecords: 0, FilenamesSize: 204, CoverageSize: 0, Version: 6)
    Filenames: (NFilenames: 13, UncompressedLen: 919, CompressedLen: 199)
      0: ./ios/foundations/StringFoundation/Sources/Character+Emoji.swift
      1: ./ios/foundations/StringFoundation/Sources/OptionalString+IsNilOrEmptyOrWhitespace.swif
      ...
```

#### References
* [LLVM Code Coverage Mapping Format](https://llvm.org/docs/CoverageMappingFormat.html)
* [CoverageMapping source code](https://github.com/apple/llvm-project/blob/4305e61a0d81cc071a88090fa8579440c2220e07/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h)

cc: @bachand