### PR TITLE
[MachO Parser] Parse __llvm_covfun

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,10 @@ jobs:
       - run: ./macho_parser sample.out
       - run: ./macho_parser sample.out --segments
       - run: ./macho_parser sample.out --symtab
+      # Tests with coverage
+      - run: cd ../testing/code_coverage && ./build_and_test.sh && cd -
+      - run: ./macho_parser ../testing/code_coverage/build/Test.xctest/Test --section __llvm_covmap
+      - run: ./macho_parser ../testing/code_coverage/build/Test.xctest/Test --section __llvm_covfun
 
   macho-parser-bazel:
     name: Macho Parser (Bazel)

--- a/macho_parser/sources/llvm_cov.cpp
+++ b/macho_parser/sources/llvm_cov.cpp
@@ -4,11 +4,13 @@
 #include "utils/utils.h"
 #include "llvm_cov.h"
 
-size_t printCovMapHeader(uint8_t *covMapBase);
-size_t printFilenamesRegion(uint8_t *filenamesBase);
-void printFilenames(uint8_t *uncompressedFileNames, int numFilenames);
-
 // https://llvm.org/docs/CoverageMappingFormat.html
+
+// BEGIN __llvm_covmap
+
+static size_t printCovMapHeader(uint8_t *covMapBase);
+static size_t printFilenamesRegion(uint8_t *filenamesBase);
+static void printFilenames(uint8_t *uncompressedFileNames, int numFilenames);
 
 void printCovMapSection(uint8_t *base, struct section_64 *sect) {
     uint8_t *covMapBase = base + sect->offset;
@@ -22,7 +24,7 @@ void printCovMapSection(uint8_t *base, struct section_64 *sect) {
 }
 
 // https://github.com/apple/llvm-project/blob/4305e61a0d81cc071a88090fa8579440c2220e07/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h#L990-L1007
-size_t printCovMapHeader(uint8_t *covMapBase) {
+static size_t printCovMapHeader(uint8_t *covMapBase) {
     uint32_t * header = (uint32_t *)covMapBase;
     // https://github.com/apple/llvm-project/blob/4305e61a0d81cc071a88090fa8579440c2220e07/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h#L1011-L1029
     uint32_t version = header[3] + 1;
@@ -36,7 +38,7 @@ size_t printCovMapHeader(uint8_t *covMapBase) {
     return 4 * 4; // CovMap header size
 }
 
-size_t printFilenamesRegion(uint8_t *filenamesBase) {
+static size_t printFilenamesRegion(uint8_t *filenamesBase) {
     uint64_t numFilenames = 0;
     uint64_t uncompressedLength = 0;
     uint64_t compressedLength = 0;
@@ -66,7 +68,7 @@ size_t printFilenamesRegion(uint8_t *filenamesBase) {
     return (offset + 7) / 8 * 8;
 }
 
-void printFilenames(uint8_t *uncompressedFileNames, int numFilenames) {
+static void printFilenames(uint8_t *uncompressedFileNames, int numFilenames) {
     int offset = 0;
     for (int i = 0; i < numFilenames; i++) {
         uint64_t filenameLength = 0;
@@ -76,3 +78,144 @@ void printFilenames(uint8_t *uncompressedFileNames, int numFilenames) {
         offset += filenameLength;
     }
 }
+
+// END __llvm_covmap
+
+// BEGIN __llvm_covfun
+
+static void printFunctionEncoding(uint8_t *funcEncodingBase);
+static size_t printFileIDMapping(uint8_t *fileIDMappingBase, int *numFiles);
+static size_t parseCounterExpressions(uint8_t *counterExpressionBase, std::vector<std::pair<uint64_t, uint64_t>> &counterExpressions);
+static size_t printMappingRegions(uint8_t *mappingRegionBase, int numFiles, const std::vector<std::pair<uint64_t, uint64_t>> &counterExpressions);
+static std::string formatCounter(uint64_t counter, const std::vector<std::pair<uint64_t, uint64_t>> &counterExpressions);
+
+void printCovFunSection(uint8_t *base, struct section_64 *sect) {
+    uint8_t *covFunBase = base + sect->offset;
+
+    int index = 0;
+
+    size_t offset = 0;
+    while (offset < sect->size) {
+        // The hashes here are the lower 64 bits of the MD5 hash
+        int64_t funcNameHash = *(int64_t *)(covFunBase + offset);
+        offset += sizeof(int64_t);
+        int32_t dataLen = *(int32_t *)(covFunBase + offset);
+        offset += sizeof(int32_t);
+        int64_t funcHash = *(int64_t *)(covFunBase + offset);
+        offset += sizeof(int64_t);
+        int64_t fileNameHash = *(int64_t *)(covFunBase + offset);
+        offset += sizeof(int64_t);
+
+        printf("%d: FuncNameHash: 0x%llx, DataLen: %d, FuncHash: 0x%llx, FileNameHash: 0x%llx\n", index++, funcNameHash, dataLen, funcHash, fileNameHash);
+        printFunctionEncoding(covFunBase + offset);
+
+        offset += dataLen;
+        offset = (offset + 7) / 8 * 8; // align to 8 bytes
+    }
+}
+
+static void printFunctionEncoding(uint8_t *funcEncodingBase) {
+    std::vector<std::pair<uint64_t, uint64_t>> counterExpressions;
+    int numFiles = 0;
+    size_t offset = printFileIDMapping(funcEncodingBase, &numFiles);
+    offset += parseCounterExpressions(funcEncodingBase + offset, counterExpressions);
+    offset += printMappingRegions(funcEncodingBase + offset, numFiles, counterExpressions);
+}
+
+static size_t printFileIDMapping(uint8_t *fileIDMappingBase, int *numFiles) {
+    uint64_t numIndices = 0;
+    size_t offset = readULEB128(fileIDMappingBase, &numIndices);
+
+    printf("    FileIDMapping: (NFiles: %llu)\n", numIndices);
+
+    for (int i = 0; i < numIndices; i++) {
+        uint64_t filenameIndex = 0;
+        offset += readULEB128(fileIDMappingBase + offset, &filenameIndex);
+
+        printf("     %2d: %llu\n", i, filenameIndex);
+    }
+
+    *numFiles = numIndices;
+    return offset;
+}
+
+// Parse counter expressions into a vector of pairs of (LHS, RHS) and return the bytes that have been processed
+static size_t parseCounterExpressions(uint8_t *counterExpressionBase, std::vector<std::pair<uint64_t, uint64_t>> &counterExpressions) {
+    uint64_t numExpressions = 0;
+    size_t offset = readULEB128(counterExpressionBase, &numExpressions);
+
+    for (int i = 0; i < numExpressions; i++) {
+        uint64_t exprLHS = 0, exprRHS = 0;
+        offset += readULEB128(counterExpressionBase + offset, &exprLHS);
+        offset += readULEB128(counterExpressionBase + offset, &exprRHS);
+
+        counterExpressions.push_back(std::make_pair(exprLHS, exprRHS));
+    }
+
+    return offset;
+}
+
+static size_t printMappingRegions(uint8_t *mappingRegionBase, int numFiles, const std::vector<std::pair<uint64_t, uint64_t>> &counterExpressions) {
+    size_t offset = 0;
+
+    printf("    MappingRegions: (NRegionArrays: %d)\n", numFiles);
+
+    for (int i = 0; i < numFiles; i++) {
+        uint64_t numRegions = 0;
+        offset += readULEB128(mappingRegionBase + offset, &numRegions);
+
+        printf("     %2d: (NRegions: %llu)\n", i, numRegions);
+
+        int prevLinStart = 0;
+        for (int j = 0; j < numRegions; j++) {
+            uint64_t counter = 0;
+            offset += readULEB128(mappingRegionBase + offset, &counter);
+
+            uint64_t deltaLineStart = 0, columnStart = 0, numLines = 0, columnEnd = 0;
+            offset += readULEB128(mappingRegionBase + offset, &deltaLineStart);
+            offset += readULEB128(mappingRegionBase + offset, &columnStart);
+            offset += readULEB128(mappingRegionBase + offset, &numLines);
+            offset += readULEB128(mappingRegionBase + offset, &columnEnd);
+
+            int lineStart = (j == 0 ? deltaLineStart : prevLinStart + deltaLineStart);
+
+            // Map region to counter
+            printf("         %d: %d:%llu => %llu:%llu : ", j, lineStart, columnStart, lineStart + numLines, columnEnd);
+            std::cout << formatCounter(counter, counterExpressions) << std::endl;
+
+            prevLinStart = lineStart;
+        }
+    }
+
+    return offset;
+}
+
+// Format the counter into a string.
+static std::string formatCounter(uint64_t counter, const std::vector<std::pair<uint64_t, uint64_t>> &counterExpressions) {
+    std::string result = "";
+
+    // The lower 2 bits of the counter are used to encode the tag of the counter.
+    uint8_t tag = counter & 0x3;
+    uint64_t counterIndex = counter >> 2;
+
+    if (tag == 0) {
+        result += "pseudo-counter";
+    } else if (tag == 1) {
+        // The counter is a reference to the profile instrumentation counter.
+        result += std::to_string(counterIndex);
+    } else {
+        // The counter is a subtraction or addition expression.
+        std::pair<uint64_t, uint64_t> expression = counterExpressions[counterIndex];
+        uint64_t lhs = expression.first;
+        uint64_t rhs = expression.second;
+        result += "(";
+        result += formatCounter(lhs, counterExpressions);
+        result += tag == 2 ? " - " : " + ";
+        result += formatCounter(rhs, counterExpressions);
+        result += ")";
+    }
+
+    return result;
+}
+
+// END __llvm_covfun

--- a/macho_parser/sources/llvm_cov.cpp
+++ b/macho_parser/sources/llvm_cov.cpp
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <iostream>
+#include <vector>
 
 #include "utils/utils.h"
 #include "llvm_cov.h"

--- a/macho_parser/sources/llvm_cov.h
+++ b/macho_parser/sources/llvm_cov.h
@@ -9,6 +9,8 @@ extern "C" {
 
 void printCovMapSection(uint8_t *base, struct section_64 *sect);
 
+void printCovFunSection(uint8_t *base, struct section_64 *sect);
+
 #ifdef __cplusplus
 }
 #endif

--- a/macho_parser/sources/segment_64.c
+++ b/macho_parser/sources/segment_64.c
@@ -90,6 +90,9 @@ static void print_section(void *base, struct section_64 sect, int section_index)
     if (strncmp(sect.sectname, "__llvm_covmap", 16) == 0) {
         printCovMapSection(base, &sect);
     }
+    else if (strncmp(sect.sectname, "__llvm_covfun", 16) == 0) {
+        printCovFunSection(base, &sect);
+    }
     // (__TEXT,__cstring), (__TEXT,__objc_classname__TEXT), (__TEXT,__objc_methname), etc..
     else if (type == S_CSTRING_LITERALS) {
 

--- a/testing/code_coverage/build_and_test.sh
+++ b/testing/code_coverage/build_and_test.sh
@@ -2,8 +2,7 @@
 # This script was tested on Xcode 14.3
 set -e
 
-# Change the target to arm64 to run tests natively on M1 machine
-TARGET="arm64-apple-ios15.2-simulator"
+TARGET="$(uname -m)-apple-ios15.2-simulator"
 
 SDKROOT=$(xcrun --show-sdk-path --sdk iphonesimulator)
 PLATFORM_DIR="$(xcode-select -p)/Platforms/iPhoneSimulator.platform"

--- a/testing/code_coverage/build_and_test.sh
+++ b/testing/code_coverage/build_and_test.sh
@@ -44,7 +44,7 @@ rm -f $PROFRAW_FILE $PROFDATA_FILE
 
 xcrun simctl spawn --arch=$ARCH --standalone "iPhone 14 Pro"  \
     "$PLATFORM_DIR/Developer/Library/Xcode/Agents/xctest" \
-    $(realpath build/Test.xctest)
+    $PWD/build/Test.xctest
 
 xcrun llvm-profdata merge -sparse "$PROFRAW_FILE" -o "$PROFDATA_FILE"
 
@@ -56,8 +56,8 @@ echo ""
 
 # Export json report
 xcrun llvm-cov export $COMMON_OPTIONS --format=text $TEST_BINARY > coverage.json
-echo "Generated JSON report at $(realpath coverage.json)"
+echo "Generated JSON report at $PWD/coverage.json"
 
 # Generate HTML report
 xcrun llvm-cov show $COMMON_OPTIONS --format=html --output-dir=report $TEST_BINARY
-echo "Generated HTML report at $(realpath report/index.html)"
+echo "Generated HTML report at $PWD/report/index.html"


### PR DESCRIPTION
Parse `__LLVM_COV,__llvm_covfun` section.

```
LC_SEGMENT_64        cmdsize: 1512   segname:                file: 0x00000728-0x00000eb8 1.89KB     vm: 0x000000000-0x000000790 1.89KB    prot: 7/7
   9: 0x000000b40-0x000000c05 197B        (__LLVM_COV,__llvm_covfun)        type: S_REGULAR  offset: 2880
0: FuncNameHash: 0x7a98ea6a153a94e6, DataLen: 50, FuncHash: 0x0, FileNameHash: 0xb56f2617839bb79c
    FileIDMapping: (NFiles: 1)
      0: 0
    MappingRegions: (NRegionArrays: 1)
      0: (NRegions: 8)
         0: 2:39 => 10:6 : 0
         1: 3:12 => 3:28 : 0
         2: 3:29 => 5:10 : 1
         3: 5:10 => 10:6 : (0 - 1)
         4: 5:19 => 5:35 : (0 - 1)
         5: 5:36 => 7:10 : 2
         6: 7:10 => 10:6 : ((0 - 1) - 2)
         7: 7:16 => 9:10 : ((0 - 1) - 2)
```