### PR TITLE
[MachO Parser] Parse __llvm_prf_names

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,7 @@ jobs:
       - run: cd ../testing/code_coverage && ./build_and_test.sh && cd -
       - run: ./macho_parser ../testing/code_coverage/build/Test.xctest/Test --section __llvm_covmap
       - run: ./macho_parser ../testing/code_coverage/build/Test.xctest/Test --section __llvm_covfun
+      - run: ./macho_parser ../testing/code_coverage/build/Test.xctest/Test --section __llvm_prf_names
 
   macho-parser-bazel:
     name: Macho Parser (Bazel)

--- a/macho_parser/sources/argument.cpp
+++ b/macho_parser/sources/argument.cpp
@@ -273,7 +273,8 @@ bool showSection(int sectIndex, char *sectName) {
 
     if (!show) {
         // check if the section name is specified
-        show = std::find(specifiedSectNames.begin(), specifiedSectNames.end(), sectName) != specifiedSectNames.end();
+        auto sectionName = std::string(sectName, std::min<size_t>(strlen(sectName), 16));
+        show = std::find(specifiedSectNames.begin(), specifiedSectNames.end(), sectionName) != specifiedSectNames.end();
     }
 
     return show;

--- a/macho_parser/sources/llvm_cov.cpp
+++ b/macho_parser/sources/llvm_cov.cpp
@@ -16,11 +16,14 @@ static void printFilenames(uint8_t *uncompressedFileNames, int numFilenames);
 void printCovMapSection(uint8_t *base, struct section_64 *sect) {
     uint8_t *covMapBase = base + sect->offset;
 
+    int index = 0;
+
     size_t offset = 0;
     while (offset < sect->size) {
-        printf("\n");
+        std::cout << "  === " << index++ << " ===" << std::endl;
         offset += printCovMapHeader(covMapBase + offset);
         offset += printFilenamesRegion(covMapBase + offset);
+        std::cout << std::endl;
     }
 }
 
@@ -29,7 +32,7 @@ static size_t printCovMapHeader(uint8_t *covMapBase) {
     uint32_t * header = (uint32_t *)covMapBase;
     // https://github.com/apple/llvm-project/blob/4305e61a0d81cc071a88090fa8579440c2220e07/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h#L1011-L1029
     uint32_t version = header[3] + 1;
-    printf("CovMap Header: (NRecords: %d, FilenamesSize: %d, CoverageSize: %d, Version: %d)\n", header[0], header[1], header[2], version);
+    printf("  CovMap Header: (NRecords: %d, FilenamesSize: %d, CoverageSize: %d, Version: %d)\n", header[0], header[1], header[2], version);
 
     if (version < 4) {
         std::cerr << "Coverage map version lower than 4 is not supported." << std::endl;
@@ -50,7 +53,7 @@ static size_t printFilenamesRegion(uint8_t *filenamesBase) {
     offset += readULEB128(filenamesBase + offset, &uncompressedLength);
     offset += readULEB128(filenamesBase + offset, &compressedLength);
 
-    printf("    Filenames: (NFilenames: %llu, UncompressedLen: %llu, CompressedLen: %llu)\n", numFilenames, uncompressedLength, compressedLength);
+    printf("  Filenames: (NFilenames: %llu, UncompressedLen: %llu, CompressedLen: %llu)\n", numFilenames, uncompressedLength, compressedLength);
 
     uint8_t *uncompressedData = (uint8_t *)malloc(uncompressedLength);;
     if (compressedLength > 0) {
@@ -75,7 +78,7 @@ static void printFilenames(uint8_t *uncompressedFileNames, int numFilenames) {
         uint64_t filenameLength = 0;
         offset += readULEB128(uncompressedFileNames + offset, &filenameLength);
 
-        printf("     %2d: %.*s\n", i, (int)filenameLength, uncompressedFileNames + offset);
+        printf("    %2d: %.*s\n", i, (int)filenameLength, uncompressedFileNames + offset);
         offset += filenameLength;
     }
 }

--- a/macho_parser/sources/llvm_cov.cpp
+++ b/macho_parser/sources/llvm_cov.cpp
@@ -227,7 +227,7 @@ std::vector<std::string> splitString(const std::string& input, char delimiter);
 void printPrfNamesSection(uint8_t *base, struct section_64 *sect) {
     uint8_t *prfNamesBase = base + sect->offset;
 
-    std::cout << std::endl;
+    int index = 0;
 
     size_t offset = 0;
     while (offset < sect->size) {
@@ -245,6 +245,8 @@ void printPrfNamesSection(uint8_t *base, struct section_64 *sect) {
             memcpy(uncompressedData, prfNamesBase + offset, uncompressedSize);
             offset += uncompressedSize;
         }
+
+        std::cout << "  === " << index++ << " ===" << std::endl;
 
         auto names = splitString((char *)uncompressedData, '\1');
         for (auto name : names) {

--- a/macho_parser/sources/llvm_cov.h
+++ b/macho_parser/sources/llvm_cov.h
@@ -11,6 +11,8 @@ void printCovMapSection(uint8_t *base, struct section_64 *sect);
 
 void printCovFunSection(uint8_t *base, struct section_64 *sect);
 
+void printPrfNamesSection(uint8_t *base, struct section_64 *sect);
+
 #ifdef __cplusplus
 }
 #endif

--- a/macho_parser/sources/segment_64.c
+++ b/macho_parser/sources/segment_64.c
@@ -89,19 +89,17 @@ static void print_section(void *base, struct section_64 sect, int section_index)
 
     if (strncmp(sect.sectname, "__llvm_covmap", 16) == 0) {
         printCovMapSection(base, &sect);
-    }
-    else if (strncmp(sect.sectname, "__llvm_covfun", 16) == 0) {
+    } else if (strncmp(sect.sectname, "__llvm_covfun", 16) == 0) {
         printCovFunSection(base, &sect);
-    }
-    // (__TEXT,__cstring), (__TEXT,__objc_classname__TEXT), (__TEXT,__objc_methname), etc..
-    else if (type == S_CSTRING_LITERALS) {
-
+    } else if (strncmp(sect.sectname, "__llvm_prf_names", 16) == 0) {
+        printPrfNamesSection(base, &sect);
+    } else if (type == S_CSTRING_LITERALS) {
+        // (__TEXT,__cstring), (__TEXT,__objc_classname__TEXT), (__TEXT,__objc_methname), etc..
         print_cstring_section(base, &sect);
-    }
-    // (__DATA_CONST,__mod_init_func)
-    else if (type == S_MOD_INIT_FUNC_POINTERS
+    } else if (type == S_MOD_INIT_FUNC_POINTERS
         || type == S_NON_LAZY_SYMBOL_POINTERS
         || type == S_LAZY_SYMBOL_POINTERS) {
+        // (__DATA_CONST,__mod_init_func)
         print_pointer_section(base, &sect);
     }
 }


### PR DESCRIPTION
Parse `__DATA,__llvm_prf_names`

```
LC_SEGMENT_64        cmdsize: 1832   segname:                file: 0x00000d30-0x00002038 4.76KB     vm: 0x000000000-0x000001308 4.76KB    prot: 7/7
  18: 0x000001c28-0x000001c8a 98B         (__DATA,__llvm_prf_names)         type: S_REGULAR  offset: 7208

  Test.swift:Test.Tests.testExample() throws -> ()
  Test.swift:implicit closure #1 () throws -> Swift.Bool in Test.Tests.testExample() throws -> ()
  Test.swift:implicit closure #2 () throws -> Swift.Bool in Test.Tests.testExample() throws -> ()
  Lib.swift:Test.Foo.func1(a: Swift.Int) -> Swift.Int
  Lib.swift:Test.Foo.func2() -> Swift.Int
```