### PR TITLE
[Mach-O Parser] Support basic LC_ATOM_INFO

### DIFF
--- a/macho_parser/sources/linkedit_data.c
+++ b/macho_parser/sources/linkedit_data.c
@@ -59,6 +59,9 @@ static char *command_name(uint32_t cmd) {
     case LC_DYLD_CHAINED_FIXUPS:
         cmd_name = "LC_DYLD_CHAINED_FIXUPS";
         break;
+    case LC_ATOM_INFO:
+        cmd_name = "LC_ATOM_INFO";
+        break;
     default:
         break;
     }

--- a/macho_parser/sources/linkedit_data.c
+++ b/macho_parser/sources/linkedit_data.c
@@ -59,8 +59,10 @@ static char *command_name(uint32_t cmd) {
     case LC_DYLD_CHAINED_FIXUPS:
         cmd_name = "LC_DYLD_CHAINED_FIXUPS";
         break;
+#if __clang_major__ >= 15
     case LC_ATOM_INFO:
         cmd_name = "LC_ATOM_INFO";
+#endif
         break;
     default:
         break;

--- a/macho_parser/sources/macho_header.cpp
+++ b/macho_parser/sources/macho_header.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 #include <map>
 #include <cmath>
+#include <cassert>
 
 extern "C" {
 #include "util.h"

--- a/macho_parser/sources/main.cpp
+++ b/macho_parser/sources/main.cpp
@@ -149,7 +149,9 @@ static void printLoadCommands(uint8_t *base, std::vector<struct load_command *> 
             case LC_DYLD_EXPORTS_TRIE:
             case LC_DYLD_CHAINED_FIXUPS:
             case LC_SEGMENT_SPLIT_INFO:
+#if __clang_major__ >= 15
             case LC_ATOM_INFO:
+#endif
                 parse_linkedit_data(base, (struct linkedit_data_command *)lcmd);
                 break;
             case LC_BUILD_VERSION:

--- a/macho_parser/sources/main.cpp
+++ b/macho_parser/sources/main.cpp
@@ -149,6 +149,7 @@ static void printLoadCommands(uint8_t *base, std::vector<struct load_command *> 
             case LC_DYLD_EXPORTS_TRIE:
             case LC_DYLD_CHAINED_FIXUPS:
             case LC_SEGMENT_SPLIT_INFO:
+            case LC_ATOM_INFO:
                 parse_linkedit_data(base, (struct linkedit_data_command *)lcmd);
                 break;
             case LC_BUILD_VERSION:


### PR DESCRIPTION
`LC_ATOM_INFO` is a new load command that supports "mergeable libraries" added in Xcode 15. 