### PR TITLE
[Mach-O Parser] Hexdump the file range for linkedit load command

### DIFF
--- a/macho_parser/sources/argument.cpp
+++ b/macho_parser/sources/argument.cpp
@@ -217,6 +217,9 @@ static uint8_t getCommandTypeFromString(char *commandString) {
         { "LC_DYLD_ENVIRONMENT",    LC_DYLD_ENVIRONMENT },
         { "LC_CODE_SIGNATURE",      LC_CODE_SIGNATURE },
         { "LC_ENCRYPTION_INFO_64",  LC_ENCRYPTION_INFO_64 },
+#if __clang_major__ >= 15
+        { "LC_ATOM_INFO",           LC_ATOM_INFO },
+#endif
     };
 
     std::string key = std::string(commandString);

--- a/macho_parser/sources/linkedit_data.cpp
+++ b/macho_parser/sources/linkedit_data.cpp
@@ -30,6 +30,8 @@ void printLinkEditData(uint8_t *base, struct linkedit_data_command *linkEditData
         printExportTrie(base, linkEditDataCmd->dataoff, linkEditDataCmd->datasize);
     } else if (linkEditDataCmd->cmd == LC_CODE_SIGNATURE) {
         printCodeSignature(base, linkEditDataCmd->dataoff, linkEditDataCmd->datasize);
+    } else {
+        hexdump(linkEditDataCmd->dataoff, base + linkEditDataCmd->dataoff, linkEditDataCmd->datasize);
     }
 }
 

--- a/macho_parser/sources/utils/hexdump.cpp
+++ b/macho_parser/sources/utils/hexdump.cpp
@@ -1,0 +1,49 @@
+#include <iostream>
+#include <iomanip>
+
+// Hex dump a range of memory to stdout
+// This method is mostly written by ChatGPT
+void hexdump(uint32_t start, const void* data, size_t size)
+{
+    const unsigned char* bytes = static_cast<const unsigned char*>(data);
+    size_t offset = 0;
+
+    for (size_t i = 0; i < size; i += 16)
+    {
+        // Print the current offset
+        std::cout << std::hex << std::setw(8) << std::setfill('0') << start + offset << ": ";
+
+        // Print hex values for this row
+        for (size_t j = 0; j < 16; ++j)
+        {
+            if (i + j < size)
+                std::cout << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(bytes[i + j]);
+            else
+                std::cout << "  ";
+
+            if (j % 2 == 1)
+                std::cout << ' ';
+        }
+
+        std::cout << ' ';
+
+        // Print ASCII values for this row
+        for (size_t j = 0; j < 16; ++j)
+        {
+            if (i + j < size)
+            {
+                if (bytes[i + j] >= 32 && bytes[i + j] <= 126)
+                    std::cout << static_cast<char>(bytes[i + j]);
+                else
+                    std::cout << '.';
+            }
+            else
+            {
+                std::cout << ' ';
+            }
+        }
+
+        std::cout << '\n';
+        offset += 16;
+    }
+}

--- a/macho_parser/sources/utils/utils.h
+++ b/macho_parser/sources/utils/utils.h
@@ -2,10 +2,7 @@
 #define MACHO_PARSER_UTILS_H
 
 #include <stdlib.h>
-
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include <string>
 
 // Read a uleb128 number int to `out` and return the number of bytes processed.
 // This method assumes the input correctness and doesn't handle error cases.
@@ -18,20 +15,13 @@ int readSLEB128(const uint8_t *p, int64_t *out);
 // Decompress that data using zlib.
 void decompressZlibData(const uint8_t *inputData, size_t inputSize, uint8_t *outputData, size_t outputSize);
 
-#ifdef __cplusplus
-}
-#endif
+// Hex dump a range of memory to stdout.
+void hexdump(uint32_t start, const void* data, size_t size);
 
-
-#ifdef __cplusplus
-
-#include <string>
 // formatting
 std::string formatSize(uint64_t sizeInByte);
 std::string formatBufferToHex(const uint8_t *buffer, size_t bufferSize);
 std::string formatStringLiteral(const char *str);
 std::string formatVersion(uint32_t version);
-#endif
-
 
 #endif //MACHO_PARSER_UTILS_H


### PR DESCRIPTION
```
$ macho_parser mergeable_libraries/build/Library.dylib -c LC_ATOM_INFO
LC_ATOM_INFO         cmdsize: 16     dataoff: 0x8080 (32896)   datasize: 608
00008080: 6e6c 6470 7265 6372 0c00 0001 0000 0000  nldprecr........
00008090: 0100 0000 0000 0d00 0000 0e00 0000 0000  ................
000080a0: 0709 0533 0000 0000 0000 0000 0000 0000  ...3............
000080b0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
000080c0: 0000 0000 0000 0000 0000 0000 807f ffff  ................
000080d0: e084 0000 6002 0000 0100 0a00 0300 0000  ....`...........
000080e0: b000 0000 0100 0000 2801 0000 0000 0000  ........(.......
000080f0: 3801 0000 0000 0000 3801 0000 0200 0000  8.......8.......
00008100: 3801 0000 0802 0000 3400 0000 4002 0000  8.......4...@...
00008110: 2000 0000 6801 0000 4900 0000 b801 0000   ...h...I.......
00008120: 5000 0000 0000 0000 0000 0000 0000 0000  P...............
00008130: 50ff ffff 0000 00ff 0302 0200 0000 0000  P...............
```