### PR TITLE
Code Coverage on Test Crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This repo is mostly my study notes about low level iOS.
 * Testing
     * [Behind the scenes: iOS Testing](./articles/iOSTesting.md)
     * [Behind the scenes: Code Coverage](./articles/CodeCoverage.md)
+    * [Code Coverage on Test Crash](./articles/CodeCoverageOnTestCrash.md)
     * [Archived] [XCTest](./xctest)
 * Xcode
     * [Behind the scenes: SwiftUI Previews](./articles/SwiftUIPreview.md)

--- a/articles/CodeCoverageOnTestCrash.md
+++ b/articles/CodeCoverageOnTestCrash.md
@@ -3,9 +3,9 @@
 
 The process of code coverage gathering involves generating a `.profraw` file, which contains instrument data, upon completing the test. This `.profraw` file is then processed to create the coverage report. However, if a test prematurely crashes, this process falls apart. Despite the test runner's ability to continue with the remaining test cases, the coverage data compiled up to the point of the crash is lost.
 
-Upon investigating the source code ([InstrProfilingFile.c](https://github.com/llvm/llvm-project/blob/f7ab79f33ef5609a2d8519cbfc676842d617eeb3/compiler-rt/lib/profile/InstrProfilingFile.c)), I discovered that the function [`__llvm_profile_write_file`](https://github.com/llvm/llvm-project/blob/f7ab79f33ef5609a2d8519cbfc676842d617eeb3/compiler-rt/lib/profile/InstrProfilingFile.c#L1033) is responsible for writing to the profraw file. This function, registered in the [`atexit`](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/atexit.3.html) handler, is triggered either when `exit()` is called or when `main()` returns, but not when `abort()` is called. Hence, this function isn't executed when the program encounters a crash, explaining a 0 byte .profraw file we saw following a crash.
+Upon investigating the source code ([InstrProfilingFile.c](https://github.com/llvm/llvm-project/blob/f7ab79f33ef5609a2d8519cbfc676842d617eeb3/compiler-rt/lib/profile/InstrProfilingFile.c)), I discovered that the function [`__llvm_profile_write_file`](https://github.com/llvm/llvm-project/blob/f7ab79f33ef5609a2d8519cbfc676842d617eeb3/compiler-rt/lib/profile/InstrProfilingFile.c#L1033) is responsible for writing to the profraw file. This function, [registered](https://github.com/llvm/llvm-project/blob/f7ab79f33ef5609a2d8519cbfc676842d617eeb3/compiler-rt/lib/profile/InstrProfilingFile.c#L1166) in the [`atexit`](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/atexit.3.html) handler, is triggered either when `exit()` is called or when `main()` returns, but not when `abort()` is called. Hence, this function isn't executed when the program encounters a crash, explaining a 0 byte `.profraw` file we saw following a crash.
 
-This situation seemed quite unfortunate until I noticed something while closely examining the function body and saw this.
+This seemed unfortunate until I noticed something while closely examining the function body and saw this,
 ```c
 if (lprofProfileDumped() || __llvm_profile_is_continuous_mode_enabled()) {
     PROF_NOTE("Profile data not written to file: %s.\n", "already written");
@@ -13,13 +13,14 @@ if (lprofProfileDumped() || __llvm_profile_is_continuous_mode_enabled()) {
 }
 ```
 
-The term "continuous mode" is interesting, so I delved in deeper and found that the continuous mode can be activated by adding "**%c**" into the profraw file name. Honestly, it's a quite weird way to enable a feature. As the name implies, the continuous mode allows for continuously writing to the profraw file instead of waiting until the end. This exactly what we need.
+The "continuous mode" sounds interesting, so I delved in deeper and found that the continuous mode can be [enabled](https://github.com/llvm/llvm-project/blob/f7ab79f33ef5609a2d8519cbfc676842d617eeb3/compiler-rt/lib/profile/InstrProfilingFile.c#L771) by adding "**%c**" into the profraw file name. Honestly, it's a quite weird way to enable a feature. As the name implies, the continuous mode allows for continuously writing to the profraw file instead of waiting until the end. This is exactly what we need.
 
 I later discovered that this feature is actually [documented](https://clang.llvm.org/docs/SourceBasedCodeCoverage.html#running-the-instrumented-program).
+> “%c” expands out to nothing, but enables a mode in which profile counter updates are continuously synced to a file. This means that if the instrumented program crashes, or is killed by a signal, perfect coverage information can still be recovered. Continuous mode does not support value profiling for PGO, and is only supported on Darwin at the moment. Support for Linux may be mostly complete but requires testing, and support for Windows may require more extensive changes: please get involved if you are interested in porting this feature.
 
 ### TL;DR
 > [!IMPORTANT]
-> Always use "%c" when specifying `LLVM_PROFILE_FILE`, so that we don't loose the code coverage when test crashes.
+> Always use "**%c**" in the file name specified in `LLVM_PROFILE_FILE`, so that we don't loose the code coverage when test crashes.
 
 ### References
 [Demystifying the profraw format](https://leodido.dev/demystifying-profraw/)

--- a/articles/CodeCoverageOnTestCrash.md
+++ b/articles/CodeCoverageOnTestCrash.md
@@ -1,0 +1,25 @@
+# Code Coverage On Test Crash
+(The steps of gathering code coverage is described [here](../articles/CodeCoverage.md#build-and-run).)
+
+The process of code coverage gathering involves generating a `.profraw` file, which contains instrument data, upon completing the test. This `.profraw` file is then processed to create the coverage report. However, if a test prematurely crashes, this process falls apart. Despite the test runner's ability to continue with the remaining test cases, the coverage data compiled up to the point of the crash is lost.
+
+Upon investigating the source code ([InstrProfilingFile.c](https://github.com/llvm/llvm-project/blob/f7ab79f33ef5609a2d8519cbfc676842d617eeb3/compiler-rt/lib/profile/InstrProfilingFile.c)), I discovered that the function [`__llvm_profile_write_file`](https://github.com/llvm/llvm-project/blob/f7ab79f33ef5609a2d8519cbfc676842d617eeb3/compiler-rt/lib/profile/InstrProfilingFile.c#L1033) is responsible for writing to the profraw file. This function, registered in the [`atexit`](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/atexit.3.html) handler, is triggered either when `exit()` is called or when `main()` returns, but not when `abort()` is called. Hence, this function isn't executed when the program encounters a crash, explaining a 0 byte .profraw file we saw following a crash.
+
+This situation seemed quite unfortunate until I noticed something while closely examining the function body and saw this.
+```c
+if (lprofProfileDumped() || __llvm_profile_is_continuous_mode_enabled()) {
+    PROF_NOTE("Profile data not written to file: %s.\n", "already written");
+    return 0;
+}
+```
+
+The term "continuous mode" is interesting, so I delved in deeper and found that the continuous mode can be activated by adding "**%c**" into the profraw file name. Honestly, it's a quite weird way to enable a feature. As the name implies, the continuous mode allows for continuously writing to the profraw file instead of waiting until the end. This exactly what we need.
+
+I later discovered that this feature is actually [documented](https://clang.llvm.org/docs/SourceBasedCodeCoverage.html#running-the-instrumented-program).
+
+### TL;DR
+> [!IMPORTANT]
+> Always use "%c" when specifying `LLVM_PROFILE_FILE`, so that we don't loose the code coverage when test crashes.
+
+### References
+[Demystifying the profraw format](https://leodido.dev/demystifying-profraw/)

--- a/testing/code_coverage/Test.swift
+++ b/testing/code_coverage/Test.swift
@@ -7,4 +7,8 @@ class Tests: XCTestCase {
     XCTAssert(foo.func1(a: 0) == 0)
     XCTAssert(foo.func1(a: 2) == 1)
   }
+
+  // func testForceCrash() {
+  //   assertionFailure("Crash")
+  // }
 }

--- a/testing/code_coverage/build_and_test.sh
+++ b/testing/code_coverage/build_and_test.sh
@@ -37,13 +37,17 @@ xcrun clang -bundle -o $TEST_BINARY build/Test.o \
 PROFRAW_FILE="/tmp/test.profraw"
 PROFDATA_FILE="/tmp/test.profdata"
 
-export SIMCTL_CHILD_LLVM_PROFILE_FILE="$PROFRAW_FILE"
+# %c enables a mode in which profile counter updates are continuously synced to a file
+export SIMCTL_CHILD_LLVM_PROFILE_FILE="$PROFRAW_FILE%c"
 
 rm -f $PROFRAW_FILE $PROFDATA_FILE
 
+# Don't exit if test fails
+set +e
 xcrun simctl spawn --arch=$ARCH --standalone "iPhone 14 Pro"  \
     "$PLATFORM_DIR/Developer/Library/Xcode/Agents/xctest" \
     $PWD/build/Test.xctest
+set -e
 
 xcrun llvm-profdata merge -sparse "$PROFRAW_FILE" -o "$PROFDATA_FILE"
 


### PR DESCRIPTION
Adding documentation for the case of code coverage on test crash.