### PR TITLE
[iOS] Update build_ios_app for Xcode 26

### DIFF
--- a/build_ios_app/Sources/AppDelegate.swift
+++ b/build_ios_app/Sources/AppDelegate.swift
@@ -15,20 +15,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   var window: UIWindow?
 
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-    let window = UIWindow(frame: UIScreen.main.bounds)
-
-    if #available(iOS 13.0, *) {
-      window.rootViewController = UIHostingController(rootView: SwiftUIView())
-    } else {
-      window.rootViewController = ViewController()
-    }
-    // Show the window
-    window.makeKeyAndVisible()
-    self.window = window
-
     callMethods()
-
     return true
+  }
+
+  func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+    let config = UISceneConfiguration(name: nil, sessionRole: connectingSceneSession.role)
+    config.delegateClass = SceneDelegate.self
+    return config
   }
 
   func callMethods() {

--- a/build_ios_app/Sources/Info.plist
+++ b/build_ios_app/Sources/Info.plist
@@ -26,6 +26,11 @@
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+	</dict>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/build_ios_app/Sources/SceneDelegate.swift
+++ b/build_ios_app/Sources/SceneDelegate.swift
@@ -1,0 +1,14 @@
+import UIKit
+import SwiftUI
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+  var window: UIWindow?
+
+  func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+    guard let windowScene = scene as? UIWindowScene else { return }
+    let window = UIWindow(windowScene: windowScene)
+    window.rootViewController = UIHostingController(rootView: SwiftUIView())
+    window.makeKeyAndVisible()
+    self.window = window
+  }
+}

--- a/build_ios_app/build.sh
+++ b/build_ios_app/build.sh
@@ -6,7 +6,7 @@ set -e
 # --minos: set minimum os version
 OPT_DEVICE=0
 OPT_RELEASE=0
-OPT_MINOS="14.0"
+OPT_MINOS="26.0"
 while [[ $# -gt 0 ]]; do
     case "$1" in
         -d|--device)
@@ -33,13 +33,15 @@ done
 APP_NAME="SampleApp"
 
 if [[ $OPT_DEVICE == 1 ]]; then
-    SDK_PATH=$(xcrun --show-sdk-path --sdk iphoneos)
+    SDK=iphoneos
+    SDK_PATH=$(xcrun --show-sdk-path --sdk $SDK)
     SWIFT_FLAGS+=(-sdk $SDK_PATH -target arm64-apple-ios${OPT_MINOS})
     CFLAGS+=(-isysroot $SDK_PATH -arch arm64 -miphoneos-version-min=${OPT_MINOS})
 else
-    SDK_PATH=$(xcrun --show-sdk-path --sdk iphonesimulator)
-    SWIFT_FLAGS+=(-sdk $(xcrun --show-sdk-path --sdk $SDK_PATH) -target x86_64-apple-ios${OPT_MINOS}-simulator)
-    CFLAGS+=(-isysroot $SDK_PATH -arch x86_64 -mios-simulator-version-min=${OPT_MINOS})
+    SDK=iphonesimulator
+    SDK_PATH=$(xcrun --show-sdk-path --sdk $SDK)
+    SWIFT_FLAGS+=(-sdk $SDK_PATH -target arm64-apple-ios${OPT_MINOS}-simulator)
+    CFLAGS+=(-isysroot $SDK_PATH -arch arm64 -mios-simulator-version-min=${OPT_MINOS})
 fi
 
 if [[ "$OPT_RELEASE" == 1 ]]; then
@@ -139,7 +141,7 @@ function build_swift_dylib() {
         -Xlinker @rpath/Frameworks/SwiftDylib.dylib
         Sources/SwiftDylib/SwiftDylib.swift
     )
-    xcrun swiftc ${SWIFT_FLAGS[@]} ${PARAMS[@]}
+    xcrun --sdk $SDK swiftc ${SWIFT_FLAGS[@]} ${PARAMS[@]}
 }
 
 function build_objc_dylib() {
@@ -152,7 +154,7 @@ function build_objc_dylib() {
         -o Build/ObjcDylib.dylib
         Sources/ObjcDylib/LLIOSObjcDylib.m
     )
-    xcrun clang ${CFLAGS[@]} ${PARAMS[@]}
+    xcrun --sdk $SDK clang ${CFLAGS[@]} ${PARAMS[@]}
 }
 
 function build_executable() {
@@ -169,9 +171,9 @@ function build_executable() {
         BUild/MixedModule/MixedModule.a
         Build/SwiftDylib.dylib
         Build/ObjcDylib.dylib
-        Sources/AppDelegate.swift Sources/ViewController.swift Sources/SwiftUIView.swift
+        Sources/AppDelegate.swift Sources/SceneDelegate.swift Sources/ViewController.swift Sources/SwiftUIView.swift
     )
-    xcrun swiftc ${SWIFT_FLAGS[@]} ${PARAMS[@]}
+    xcrun --sdk $SDK swiftc ${SWIFT_FLAGS[@]} ${PARAMS[@]}
 }
 
 function process_info_plist() {
@@ -199,7 +201,8 @@ function package_app_bundle() {
 # Note: You need to replace the signing identity with your one.
 # Find a valid signing identity by `security find-identity -v -p codesigning`.
 # You also need to change the app id and modify Entitlements.plist.
-# (It doesn't seem to be necessary to copy the provisioning profile. Idk why.)
+# (It doesn't seem to be necessary to copy the provisioning profile. Idk why.
+# Updated on April 2026: at least for Xcode 26, the provisioning profile is needed.)
 function sign_app() {
     echo ">>> Sign the app"
     identity=$(security find-identity -v -p codesigning | grep "Apple Development" | head -1 | awk '{print $2}')

--- a/build_ios_app/debug.sh
+++ b/build_ios_app/debug.sh
@@ -3,7 +3,7 @@ set -e
 
 # Modify these variables for any other apps.
 APP_BUNDLE="Build/SampleApp.app"
-SIM_NAME="iPhone 12 Pro"
+SIM_NAME="iPhone 17 Pro"
 
 function error() {
     echo "Error: $1" >&2

--- a/build_ios_app/launch.sh
+++ b/build_ios_app/launch.sh
@@ -2,7 +2,7 @@
 set -e
 
 APP_BUNDLE="Build/SampleApp.app"
-SIM_NAME="iPhone 12 Pro"
+SIM_NAME="iPhone 17 Pro"
 
 function error() {
     echo "Error: $1" >&2
@@ -37,11 +37,13 @@ if [[ "$platform" == 7 ]]; then
 
 elif [[ "$platform" == 2 ]]; then
     echo "Launching on device ..."
-    if ! command -v ios-deploy &> /dev/null
-    then
-        error "'ios-deploy' is needed to launch the app on device. \nCheck out this awesome tool (https://github.com/ios-control/ios-deploy)."
+    DEVICE_ID=$(xcrun devicectl list devices 2>&1 | grep 'connected' | awk '{print $3}')
+    if [[ -z "$DEVICE_ID" ]]; then
+        error "No connected device found."
     fi
-    ios-deploy --debug --bundle "Build/SampleApp.app"
+    xcrun devicectl device install app --device "$DEVICE_ID" "$APP_BUNDLE"
+    APP_BUNDLE_ID=$(defaults read "$(realpath $APP_BUNDLE/Info.plist)" CFBundleIdentifier)
+    xcrun devicectl device process launch --device "$DEVICE_ID" "$APP_BUNDLE_ID"
 else
     error "The target platform of the binary is neither iOS simulator nor device."
 fi


### PR DESCRIPTION
## Change summary:

Update the build_ios_app sample project to build and run cleanly with Xcode 26 / iOS 26. Fixes SDK sysroot warnings, migrates to the modern UIScene lifecycle, and replaces the deprecated `ios-deploy` with `xcrun devicectl`.
